### PR TITLE
format -replace: format files in place

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,15 +2,10 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,10 @@
 
 * thousand separator in amounts
 * check for account/cc numbers in transactions
+* fmt: remove extra whitespace from payee
+* move postings between accounts/rename account
 * balance: last reconciled posting date
+* register: filter by payee
 * register: sorting by quantity to aid finding largest transactions
 * register: cache balance on posting, show global totals with begin/end
 * stats: check closed accounts have 0 balance

--- a/cmd/coin/format.go
+++ b/cmd/coin/format.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/mkobetic/coin"
+	"github.com/mkobetic/coin/check"
 )
 
 func init() {
@@ -42,9 +43,7 @@ func (cmd *cmdFormat) execute(f io.Writer) {
 		coin.ResolveTransactions(false)
 		if cmd.replace {
 			tf, err = os.CreateTemp(path.Dir(fn), path.Base(fn))
-			if err != nil {
-				panic(err)
-			}
+			check.NoError(err, "creating temp file")
 			f = tf
 		}
 		for _, t := range coin.Transactions {
@@ -52,12 +51,10 @@ func (cmd *cmdFormat) execute(f io.Writer) {
 			fmt.Fprintln(f)
 		}
 		if cmd.replace {
-			if err = os.Remove(fn); err != nil {
-				panic(err)
-			}
-			if err = os.Rename(tf.Name(), fn); err != nil {
-				panic(err)
-			}
+			err = os.Remove(fn)
+			check.NoError(err, "deleting old file")
+			err = os.Rename(tf.Name(), fn)
+			check.NoError(err, "renaming temp file")
 		}
 		// Note that this doesn't properly get rid of transactions,
 		// postings are still referenced through the accounts,


### PR DESCRIPTION
This is handy to clean up a larger ledger, saves juggling the temp files manually.