### PR TITLE
format -t: trim excessive whitespace

### DIFF
--- a/cmd/coin/format.go
+++ b/cmd/coin/format.go
@@ -19,13 +19,15 @@ type cmdFormat struct {
 	*flag.FlagSet
 	ledger  bool
 	replace bool
+	trimWS  bool
 }
 
 func (*cmdFormat) newCommand(names ...string) command {
 	var cmd cmdFormat
 	cmd.FlagSet = newCommand(&cmd, names...)
 	cmd.BoolVar(&cmd.ledger, "ledger", false, "use ledger compatible format")
-	cmd.BoolVar(&cmd.replace, "replace", false, "format files in place")
+	cmd.BoolVar(&cmd.replace, "i", false, "format files in-place")
+	cmd.BoolVar(&cmd.trimWS, "t", false, "trim excessive whitespace")
 	return &cmd
 }
 
@@ -47,6 +49,10 @@ func (cmd *cmdFormat) execute(f io.Writer) {
 			f = tf
 		}
 		for _, t := range coin.Transactions {
+			if cmd.trimWS {
+				t.Description = trimWS(t.Description)
+				t.Note = trimWS(t.Note)
+			}
 			t.Write(f, cmd.ledger)
 			fmt.Fprintln(f)
 		}

--- a/cmd/coin/utils.go
+++ b/cmd/coin/utils.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"compress/gzip"
 	"encoding/base64"
 	"io"
@@ -42,4 +44,27 @@ func trim(ps []*coin.Posting, begin, end coin.Date) []*coin.Posting {
 		ps = ps[:to]
 	}
 	return ps
+}
+
+func trimWS(in string) string {
+	lines := bufio.NewScanner(strings.NewReader(in))
+	var w strings.Builder
+	lIsFirst := true
+	for lines.Scan() {
+		if !lIsFirst {
+			w.WriteByte('\n')
+		}
+		lIsFirst = false
+		words := bufio.NewScanner(bytes.NewReader(lines.Bytes()))
+		words.Split(bufio.ScanWords)
+		wIsFirst := true
+		for words.Scan() {
+			if !wIsFirst {
+				w.WriteByte(' ')
+			}
+			w.Write(words.Bytes())
+			wIsFirst = false
+		}
+	}
+	return w.String()
 }

--- a/cmd/coin/utils_test.go
+++ b/cmd/coin/utils_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mkobetic/coin/assert"
+)
+
+func Test_TrimWS(t *testing.T) {
+	for _, tc := range []struct {
+		in, out string
+	}{
+		{"   a  bb \n	ddd \n  ", "a bb\nddd\n"},
+		{"xx[ 7   ]\n      !yyy", "xx[ 7 ]\n!yyy"},
+	} {
+		assert.Equal(t, trimWS(tc.in), tc.out)
+	}
+}


### PR DESCRIPTION
Imported transactions often have really messy descriptions. This will trim out all the extraneous whitespace from the transaction description and notes.