### PR TITLE
Cache account balance on postings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push]
 name: Test
 jobs:
   test:

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,21 @@
 ### Features
 
+* register: show description/notes
+* test: support for generating test data
 * thousand separator in amounts
 * check for account/cc numbers in transactions
-* fmt: remove extra whitespace from payee
+
 * move postings between accounts/rename account
 * balance: last reconciled posting date
 * register: filter by payee
 * register: sorting by quantity to aid finding largest transactions
-* register: cache balance on posting, show global totals with begin/end
+* register: show account balances with begin/end
 * stats: check closed accounts have 0 balance
 * register: show posting commodity (not just total commodity)
-* register: show description/notes
 * register: recursive prints transactions within the parent tree twice
 * register: recursive totals are useless
 * better usage messages
 * balance: csv, json, chart output
-* test: support for generating test data
 * register: more advanced filtering options
 * stats: aggregate transaction/price stats by time (-y, -q, -m) and begin/end
 
@@ -25,6 +25,7 @@
   ? duplicate transactions from the same source/file should be kept?
 * sanitise sensistive information, account/cc numbers
 * commodity mismatches (USD vs CAD)
+* use ofxid for deduping
 
 ### Issues
 

--- a/account.go
+++ b/account.go
@@ -40,6 +40,7 @@ type Account struct {
 
 /*
 account Expenses:Food
+
 	note This account is all about the chicken!
 	alias food
 	payee ^(KFC|Popeyes)$
@@ -170,11 +171,10 @@ func (a *Account) Depth() int {
 }
 
 func (a *Account) CheckPostings() {
+	a.balance = NewZeroAmount(a.Commodity)
 	if len(a.Postings) == 0 {
-		a.balance = NewZeroAmount(a.Commodity)
 		return
 	}
-	a.balance = NewZeroAmount(a.Commodity)
 	for _, s := range a.Postings {
 		err := a.balance.AddIn(s.Quantity)
 		check.NoError(err, "couldn't add %a %s to balance %a %s: %s\n",
@@ -188,6 +188,9 @@ func (a *Account) CheckPostings() {
 				s.Balance,
 				s.Transaction.Location(),
 			)
+			s.Reconciled = true
+		} else {
+			s.Balance = a.balance.Copy()
 		}
 	}
 }

--- a/cmd/coin/postings.go
+++ b/cmd/coin/postings.go
@@ -65,7 +65,7 @@ func (ps postings) print(f io.Writer, opts *options) {
 	}
 	for i, s := range ps {
 		reconciled := ' '
-		if s.Balance != nil {
+		if s.Reconciled {
 			reconciled = '*'
 		}
 		args := []interface{}{
@@ -104,7 +104,7 @@ func (ps postings) printLong(f io.Writer, opts *options) {
 	}
 	for i, s := range ps {
 		reconciled := ' '
-		if s.Balance != nil {
+		if s.Reconciled {
 			reconciled = '*'
 		}
 		args := []interface{}{

--- a/cmd/ofx2coin/main_test.go
+++ b/cmd/ofx2coin/main_test.go
@@ -65,6 +65,10 @@ func Test_ReadTransactions(t *testing.T) {
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
+	assert.Equal(t, len(txs), 10)
+	// We don't resolve the transactions,
+	// so set Reconciled on last transaction so that it writes the balance.
+	txs[9].Postings[1].Reconciled = true
 	for i, tx := range []string{
 		`2019/01/04 [CK]NO.272
   Unbalanced             704.00 CAD

--- a/posting.go
+++ b/posting.go
@@ -12,7 +12,8 @@ type Posting struct {
 	Transaction *Transaction
 	Account     *Account
 	Quantity    *Amount // posting amount
-	Balance     *Amount // optional account balance assertion
+	Balance     *Amount // account balance as of this posting
+	Reconciled  bool    // was balance explicitly asserted in the ledger (only set after ResolveTransactions())
 
 	accountName string
 }
@@ -26,7 +27,7 @@ func (s *Posting) Write(w io.Writer, accountOffset, accountWidth, amountWidth in
 	if err != nil {
 		return err
 	}
-	if s.Balance != nil {
+	if s.Reconciled {
 		if _, err = io.WriteString(w, " = "); err != nil {
 			return err
 		}

--- a/transaction.go
+++ b/transaction.go
@@ -34,8 +34,8 @@ func (transactions TransactionsByTime) Swap(i, j int) {
 func (transactions TransactionsByTime) Less(i, j int) bool {
 	return transactions[i].Posted.Before(transactions[j].Posted) ||
 		(transactions[i].Posted.Equal(transactions[j].Posted) &&
-			!transactions[i].HasBalances() &&
-			transactions[j].HasBalances())
+			!transactions[i].HasReconciledPosting() &&
+			transactions[j].HasReconciledPosting())
 }
 func (transactions TransactionsByTime) FindEqual(t *Transaction) *Transaction {
 	for _, t2 := range transactions {
@@ -219,9 +219,9 @@ func (t *Transaction) Other(s *Posting) *Posting {
 	return nil
 }
 
-func (t *Transaction) HasBalances() bool {
+func (t *Transaction) HasReconciledPosting() bool {
 	for _, p := range t.Postings {
-		if p.Balance != nil {
+		if p.Reconciled {
 			return true
 		}
 	}
@@ -250,6 +250,7 @@ func (t *Transaction) MergeDuplicate(t2 *Transaction) {
 	for i, p := range t.Postings {
 		if p2 := t2.Postings[i]; p.Balance == nil && p2.Balance != nil {
 			p.Balance = p2.Balance
+			p.Reconciled = p2.Reconciled
 		}
 	}
 }


### PR DESCRIPTION
This will allow reporting account balance in register reports and other handy things.

This has to be done when resolving transactions, after an Account's postings are sorted. We are already computing a running balance while going through the postings in order to check balance assertions. With this change we also cache the running balance in Posting's Balance field. Consequently the Balance isn't optional anymore and we can't use it to detect whether balance was asserted. So we're adding Reconciled boolean to Posting, to be able to distinguish computed and asserted Balance.