### PR TITLE
Fix: balance caching broke format command

### DIFF
--- a/account.go
+++ b/account.go
@@ -188,7 +188,6 @@ func (a *Account) CheckPostings() {
 				s.Balance,
 				s.Transaction.Location(),
 			)
-			s.Reconciled = true
 		} else {
 			s.Balance = a.balance.Copy()
 		}

--- a/cmd/coin/postings.go
+++ b/cmd/coin/postings.go
@@ -65,7 +65,7 @@ func (ps postings) print(f io.Writer, opts *options) {
 	}
 	for i, s := range ps {
 		reconciled := ' '
-		if s.Reconciled {
+		if s.BalanceAsserted {
 			reconciled = '*'
 		}
 		args := []interface{}{
@@ -104,7 +104,7 @@ func (ps postings) printLong(f io.Writer, opts *options) {
 	}
 	for i, s := range ps {
 		reconciled := ' '
-		if s.Reconciled {
+		if s.BalanceAsserted {
 			reconciled = '*'
 		}
 		args := []interface{}{

--- a/cmd/ofx2coin/main_test.go
+++ b/cmd/ofx2coin/main_test.go
@@ -66,9 +66,6 @@ func Test_ReadTransactions(t *testing.T) {
 		t.FailNow()
 	}
 	assert.Equal(t, len(txs), 10)
-	// We don't resolve the transactions,
-	// so set Reconciled on last transaction so that it writes the balance.
-	txs[9].Postings[1].Reconciled = true
 	for i, tx := range []string{
 		`2019/01/04 [CK]NO.272
   Unbalanced             704.00 CAD

--- a/posting.go
+++ b/posting.go
@@ -9,11 +9,11 @@ import (
 type Posting struct {
 	Note string
 
-	Transaction *Transaction
-	Account     *Account
-	Quantity    *Amount // posting amount
-	Balance     *Amount // account balance as of this posting
-	Reconciled  bool    // was balance explicitly asserted in the ledger (only set after ResolveTransactions())
+	Transaction     *Transaction
+	Account         *Account
+	Quantity        *Amount // posting amount
+	Balance         *Amount // account balance as of this posting
+	BalanceAsserted bool    // was balance explicitly asserted in the ledger
 
 	accountName string
 }
@@ -27,7 +27,7 @@ func (s *Posting) Write(w io.Writer, accountOffset, accountWidth, amountWidth in
 	if err != nil {
 		return err
 	}
-	if s.Reconciled {
+	if s.BalanceAsserted {
 		if _, err = io.WriteString(w, " = "); err != nil {
 			return err
 		}


### PR DESCRIPTION
Format command runs ResolveTransactions(false), so it would lose balance assertions.

Replace Posting.Reconciled with Posting.BalanceAsserted and set it when transactions are parsed instead of on ResolveTransactions. It feels redundant at parse time, but stops being redundant when transactions are resolved.