### PR TITLE
register: include notes (-n)

### DIFF
--- a/cmd/coin/postings.go
+++ b/cmd/coin/postings.go
@@ -81,6 +81,9 @@ func (ps postings) print(f io.Writer, opts *options) {
 			args = append(args, trimLocation(s.Transaction.Location()))
 		}
 		fmt.Fprintf(f, fmtString, args...)
+		if opts.showNotes && (len(s.Note) > 0 || len(s.Transaction.Note) > 0) {
+			printNotes(f, strings.Repeat(" ", len(args[0].(string)))+" ;", s)
+		}
 	}
 }
 
@@ -121,7 +124,24 @@ func (ps postings) printLong(f io.Writer, opts *options) {
 			args = append(args, trimLocation(s.Transaction.Location()))
 		}
 		fmt.Fprintf(f, fmtString, args...)
+		if opts.showNotes && (len(s.Note) > 0 || len(s.Transaction.Note) > 0) {
+			printNotes(f, strings.Repeat(" ", len(args[0].(string)))+" ;", s)
+		}
 	}
+}
+
+func printNotes(w io.Writer, prefix string, p *coin.Posting) {
+	var notes string
+	if len(p.Note) > 0 {
+		notes = p.Note
+	}
+	if len(p.Transaction.Note) > 0 {
+		if len(notes) > 0 {
+			notes += "\n"
+		}
+		notes += p.Transaction.Note
+	}
+	printLines(w, prefix, notes)
 }
 
 type options struct {
@@ -129,6 +149,7 @@ type options struct {
 	location         bool
 	maxDesc, maxAcct int
 	commodity        *coin.Commodity
+	showNotes        bool
 }
 
 func (o *options) MaxDesc() int {

--- a/cmd/coin/register.go
+++ b/cmd/coin/register.go
@@ -27,6 +27,7 @@ type cmdRegister struct {
 	maxLabelWidth     int
 	location          bool
 	output            string
+	showNotes         bool
 }
 
 func (*cmdRegister) newCommand(names ...string) command {
@@ -50,6 +51,7 @@ Lists or aggregate postings from the specified account.`)
 	cmd.IntVar(&cmd.maxLabelWidth, "l", 12, "maximum width of a column label")
 	cmd.BoolVar(&cmd.location, "f", false, "include file location on postings in non-aggregated results")
 	cmd.StringVar(&cmd.output, "o", "text", "output format for aggregated results: text, json, csv, chart")
+	cmd.BoolVar(&cmd.showNotes, "n", false, "show transaction notes if present (non-aggregated)")
 	return &cmd
 }
 
@@ -71,7 +73,13 @@ func (cmd *cmdRegister) execute(f io.Writer) {
 			cmd.flatAggregatedRegister(f, acc, by)
 		}
 	} else {
-		var opts = options{prefix: acc.FullName, maxAcct: cmd.maxLabelWidth, location: cmd.location, commodity: acc.Commodity}
+		var opts = options{
+			prefix:    acc.FullName,
+			maxAcct:   cmd.maxLabelWidth,
+			location:  cmd.location,
+			commodity: acc.Commodity,
+			showNotes: cmd.showNotes,
+		}
 		if cmd.recurse {
 			var ps postings
 			acc.WithChildrenDo(func(a *coin.Account) {

--- a/cmd/coin/utils.go
+++ b/cmd/coin/utils.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"sort"
 	"strings"
@@ -67,4 +68,11 @@ func trimWS(in string) string {
 		}
 	}
 	return w.String()
+}
+
+func printLines(w io.Writer, prefix string, lines string) {
+	text := bufio.NewScanner(strings.NewReader(lines))
+	for text.Scan() {
+		fmt.Fprintln(w, prefix, text.Text())
+	}
 }

--- a/tests/cmd/reg/notes.test
+++ b/tests/cmd/reg/notes.test
@@ -1,0 +1,56 @@
+commodity CAD
+  format 1.00 CAD
+
+account Assets:Bank
+account Income:Salary
+account Expenses:Food
+account Expenses:Rent
+
+2010/01/15 ACME Inc ; paycheck
+  Bank 1000 CAD ; wat?
+  ; alleluia
+  Salary
+  ; thank
+  ; you
+
+2010/01/20 Freshco
+  Food 150 CAD
+  Bank
+  ; cheese is crazy expensive
+  ; seriously 
+
+2010/01/28 Freshco
+  Food 100 CAD
+  ; found it!
+  Bank
+
+2010/01/30 Housing Corp
+  Rent 500 CAD
+  Bank
+
+test register -n Bank
+Assets:Bank CAD
+2010/01/15 |     ACME Inc | Incom:Salary | 1000.00 | 1000.00 CAD 
+           ; alleluia
+           ; paycheck
+2010/01/20 |      Freshco | Expense:Food | -150.00 | 850.00 CAD 
+           ; cheese is crazy expensive
+           ; seriously 
+2010/01/28 |      Freshco | Expense:Food | -100.00 | 750.00 CAD 
+2010/01/30 | Housing Corp | Expense:Rent | -500.00 | 250.00 CAD 
+end test
+
+test register -n Food
+Expenses:Food CAD
+2010/01/20 | Freshco | Assets:Bank | 150.00 | 150.00 CAD 
+2010/01/28 | Freshco | Assets:Bank | 100.00 | 250.00 CAD 
+           ; found it!
+end test
+
+test register -n Salary
+Income:Salary CAD
+2010/01/15 | ACME Inc | Assets:Bank | -1000.00 | -1000.00 CAD 
+           ; thank
+           ; you
+           ; paycheck
+end test


### PR DESCRIPTION
For each posting that has a note or its transaction has a note emit an extra line in the results for each line in those notes. For example:
```
2010/01/15 ACME Inc ; paycheck
  Bank 1000 CAD
  ; alleluia
  Salary
  ; thank
  ; you

test register -n Bank
Assets:Bank CAD
2010/01/15 |     ACME Inc | Incom:Salary | 1000.00 | 1000.00 CAD 
           ; alleluia
           ; paycheck
end test

test register -n Salary
Income:Salary CAD
2010/01/15 | ACME Inc | Assets:Bank | -1000.00 | -1000.00 CAD 
           ; thank
           ; you
           ; paycheck
end test
```