### PR TITLE
format: add format command tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,11 @@
 ### Features
 
-* register: show description/notes
-* include directive
-* test: enable writing tests for the format command
+* test: verbose and terse results
 * register: filter by payee
+* include directive
+* move postings between accounts/rename account
 * thousand separator in amounts
 * check for account/cc numbers in transactions
-* move postings between accounts/rename account
 * balance: last reconciled posting date
 * register: sorting by quantity to aid finding largest transactions
 * register: show account balances with begin/end
@@ -25,7 +24,7 @@
   ? duplicate transactions from the same source/file should be kept?
 * sanitize sensitive information, account/cc numbers
 * commodity mismatches (USD vs CAD)
-* use ofxid for deduping
+* use ofxid for deduping (need tags?)
 
 ### Issues
 

--- a/cmd/coin/format.go
+++ b/cmd/coin/format.go
@@ -40,6 +40,10 @@ func (cmd *cmdFormat) init() {
 }
 
 func (cmd *cmdFormat) execute(f io.Writer) {
+	if len(cmd.Args()) == 0 {
+		cmd.writeTransactions(f)
+		return
+	}
 	for _, fn := range cmd.Args() {
 		var err error
 		var tf *os.File
@@ -50,14 +54,7 @@ func (cmd *cmdFormat) execute(f io.Writer) {
 			check.NoError(err, "creating temp file")
 			f = tf
 		}
-		for _, t := range coin.Transactions {
-			if cmd.trimWS {
-				t.Description = trimWS(t.Description)
-				t.Note = trimWS(t.Note)
-			}
-			t.Write(f, cmd.ledger)
-			fmt.Fprintln(f)
-		}
+		cmd.writeTransactions(f)
 		if cmd.replace {
 			err = os.Remove(fn)
 			check.NoError(err, "deleting old file")
@@ -68,5 +65,16 @@ func (cmd *cmdFormat) execute(f io.Writer) {
 		// postings are still referenced through the accounts,
 		// but we don't care in this case.
 		coin.Transactions = nil
+	}
+}
+
+func (cmd *cmdFormat) writeTransactions(f io.Writer) {
+	for _, t := range coin.Transactions {
+		if cmd.trimWS {
+			t.Description = trimWS(t.Description)
+			t.Note = trimWS(t.Note)
+		}
+		t.Write(f, cmd.ledger)
+		fmt.Fprintln(f)
 	}
 }

--- a/tests/cmd/fmt/basic.test
+++ b/tests/cmd/fmt/basic.test
@@ -1,0 +1,34 @@
+commodity CAD
+  format 1.00 CAD
+
+account Assets:Bank
+account Income:Salary
+account Expenses:Food
+account Expenses:Rent
+
+2000 ACME
+  Bank 1000 CAD
+  Salary
+
+2000/02 Loeb
+  Food
+  Bank -20 CAD
+
+2000/03/03 
+  Rent 500 CAD
+  Bank
+
+test format
+2000/01/01 ACME
+  Assets:Bank     1000.00 CAD
+  Income:Salary  -1000.00 CAD
+
+2000/02/01 Loeb
+  Expenses:Food   20.00 CAD
+  Assets:Bank    -20.00 CAD
+
+2000/03/03 
+  Expenses:Rent   500.00 CAD
+  Assets:Bank    -500.00 CAD
+
+end test

--- a/tests/cmd/fmt/trim.test
+++ b/tests/cmd/fmt/trim.test
@@ -1,0 +1,46 @@
+commodity CAD
+  format 1.00 CAD
+
+account Assets:Bank
+account Income:Salary
+account Expenses:Food
+account Expenses:Rent
+
+2000       ACME    Inc    ;     gimme
+  Bank 1000 CAD
+  Salary
+
+2000/02    Loeb       ;  yum    yum     yum    
+  Food
+  ;    one
+  ;           two
+  ; three
+  Bank -20 CAD ; four
+
+2000/03/03
+  ;    one
+  ;           two
+  ; three 
+  Rent 500 CAD
+  Bank
+
+test format -t
+2000/01/01 ACME Inc ; gimme
+  Assets:Bank     1000.00 CAD
+  Income:Salary  -1000.00 CAD
+
+2000/02/01 Loeb ; yum yum yum
+  Expenses:Food   20.00 CAD
+    ;    one
+    ;           two
+    ; three
+  Assets:Bank    -20.00 CAD
+
+2000/03/03 
+  ; one
+  ; two
+  ; three
+  Expenses:Rent   500.00 CAD
+  Assets:Bank    -500.00 CAD
+
+end test


### PR DESCRIPTION
Make format testable by assuming preloaded `coin.Transactions` when no files are specified. Add tests for basic format and whitespace trimming.