### PR TITLE
csv2coin: fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,16 +3,37 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
+    "inputs": [
+        { "id": "filename", "type": "promptString", "description": "Filename" },
+        { "id": "coin_cmd", "type": "promptString", "description": "Coin command" },
+    ],
     "configurations": [
         {
-            "name": "Launch",
+            "name": "Debug coin",
             "type": "go",
             "request": "launch",
-            "mode": "auto",
-            "program": "${fileDirname}",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/coin",
+            "args": ["${input:coin_cmd}"],
         },
         {
-            "name": "Launch coin test",
+            "name": "Debug ofx2coin",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/ofx2coin",
+            "args": ["-bmo", "${env:COINDB}/qfx/${input:filename}.qfx"],
+        },
+        {
+            "name": "Debug csv2coin",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/csv2coin",
+            "args": ["-source=pwl", "${env:COINDB}/csv/test.csv"],
+        },
+        {
+            "name": "Debug coin test",
             "type": "go",
             "request": "launch",
             "mode": "debug",

--- a/account.go
+++ b/account.go
@@ -36,7 +36,7 @@ type Account struct {
 	OFXBankId string
 	OFXAcctId string
 
-	CSVAcctId string
+	CSVAcctId string // obsolete; left here for backward compatibility
 }
 
 /*

--- a/cmd/coin/totals.go
+++ b/cmd/coin/totals.go
@@ -15,11 +15,14 @@ import (
 	"github.com/mkobetic/coin/check"
 )
 
+// total represents an amount total for a time period.
 type total struct {
 	time.Time
 	*coin.Amount
 }
 
+// totals aggregates time series amounts for accounts.
+// It must be initialized with a reducer before use.
 type totals struct {
 	// this must be set before using
 	*reducer

--- a/cmd/csv2coin/README.md
+++ b/cmd/csv2coin/README.md
@@ -11,9 +11,9 @@ Converts CSV files to coin transactions.
 * quantity - (optional) quantity of the commodity that was traded
 * note - (optional) note associated with the transaction
 
-Conversion of individual CSV records (lines) to these values is driven by import rules. Import rules are usually described in `$COINDB/csv.rules` file. Alternatively, if the values can be directly lifted from the full contents of specific fields of the CSV records, this mapping can be provided directly on the commandline as a list of field indexs through the `-fields` option. The order of indexes follows the order of values in the list above, e.g. `-fields=3,0,2,6,1,7,8` for an import that won't have notes.
+Conversion of individual CSV records (lines) to these values is driven by import rules. Import rules are usually described in `$COINDB/csv.rules` file. Alternatively, if the values can be directly lifted from the full contents of specific fields of the CSV records, this mapping can be provided directly on the command line as a list of field indexes through the `-fields` option. The order of indexes follows the order of values in the list above, e.g. `-fields=3,0,2,6,1,7,8` for an import that won't have notes.
 
-The transaction is composed with `account` being the "from" account. The "to" account will be produced by the rules or it is the Unbalanced account. If `symbol` and `quantity` are present the transaction will be posted as a conversion between the symbol commodity and the currency commodity. If commodity doesn't match the account a sub-account with the matching commodity will be substituted.
+The transaction is composed with `account` being the "from" account. The "to" account will be produced by the rules or it is the Unbalanced account. If `symbol` and `quantity` are present the transaction will be posted as a conversion between the symbol commodity and the currency commodity. If commodity doesn't match the account a sub-account with the matching commodity will be substituted on a first found basis (child accounts have priority), otherwise the account is set as Unbalanced.
 
 
 ## csv.rules
@@ -22,16 +22,11 @@ The file consists of two sections separated with a single line of 3 dashes (`---
 
 The first section describes known CSV sources and the value mappings for each. Different institutions structure their CSV exports differently, so each is likely to require a different source mapping, possibly several (e.g. if the export doesn't include the account ID, a separate source for each account will be required). Each source is given a name and the source to use for given import is selected via the `-source` option.
 
-The second section provides rules for picking the target accounts based on the transaction descriptions. It works exactly the same as described in [`ofx.rules`](https://github.com/mkobetic/coin/blob/master/cmd/ofx2coin/README.md#ofx.rules). When importing transactions for given account the tool will apply the rule group associated with that account. The account is matched through the account ID associated with the transaction. The same ID must also be associated with an account through the `csv_acctid` directive.
-
-```
-account Assets:Investments
-  csv_acctid XXX
-```
+The second section provides rules for picking the target accounts based on the transaction descriptions. It works exactly the same as described in [`ofx.rules`](https://github.com/mkobetic/coin/blob/master/cmd/ofx2coin/README.md#ofx.rules). When importing transactions for given account the tool will apply the rule group associated with that account. The account is matched through the account ID associated with the transaction.
 
 ### source mapping
 
-Each source description starts with a line naming the source and specifying the number of lines to skip before to get to the actual transaction records. The rest of the description consists of lines starting with whitespace and each line describing a rule for extracting a value from a record field or a rule for deriving a value from the other values. Each line starts with a value name. There should be a line for each of the required (non optional) values listed above. 
+Each source description starts with a line naming the source and specifying the number of lines to skip to get to the actual transaction records. The rest of the description consists of lines starting with whitespace and each line describing a rule for extracting a value from a record field or a rule for deriving a value from the other values. Each line starts with a value name. There should be a line for each of the required (non optional) values listed above. 
 
 #### extraction rules
 

--- a/cmd/csv2coin/main_test.go
+++ b/cmd/csv2coin/main_test.go
@@ -27,12 +27,12 @@ commodity BND
   format 1 BND
 commodity XBAL
   format 1 XBAL
-account Assets:Investments
-  csv_acctid XXX
-account Assets:Investments:VXF
+account Assets:Investments:XXX
+account Assets:Investments:XXX:VXF
   commodity VXF
+account Assets:Investments:XXX:USD
+  commodity USD
 account Assets:Investments:BBB
-  csv_acctid BBB
 account Assets:Investments:BBB:CAD
   commodity CAD
 account Assets:Investments:BBB:VAB
@@ -50,12 +50,6 @@ account Income:Interest
 `)
 	coin.Load(r, "")
 	coin.ResolveAccounts()
-
-	coin.AccountsDo(func(a *coin.Account) {
-		if a.CSVAcctId != "" {
-			accountsByCSVId[a.CSVAcctId] = a
-		}
-	})
 
 	rules = ReadRules(strings.NewReader(`src 1
   account 0
@@ -78,10 +72,10 @@ bbb 3
   symbol "${symbol_ref}" activity Buy|Sell
   quantity "${quantity_ref}" activity Buy|Sell
 ---
-XXX Assets:Investments
+XXX Assets:Investments:XXX
   Expenses:Fees Fee|HST
   Income:Dividends DRIP
-  Assets:Investments Sold|Bought
+  Assets:Investments:XXX Sold|Bought
 BBB Assets:Investments:BBB
   Income:Interest Interest
   Income:Dividends Dividend
@@ -103,16 +97,16 @@ func Test_Sample1(t *testing.T) {
 	for i, exp := range []string{
 		// symbol=VXF, quantity=123.999, amount=1630.59
 		`2019/09/10 DRIP ; blah blah VALUE =      1630.59
-  Assets:Investments:VXF   123.999 VXF
-  Income:Dividends        -1630.59 USD
+  Assets:Investments:XXX:VXF   123.999 VXF
+  Income:Dividends            -1630.59 USD
 `,
 		`2019/10/10 Sold ; whatever
-  Assets:Investments       67689.08 USD
-  Assets:Investments:VXF  -5148.219 VXF
+  Assets:Investments:XXX:USD   67689.08 USD
+  Assets:Investments:XXX:VXF  -5148.219 VXF
 `,
 		`2019/10/30 Fee ; MGMT FEE
-  Expenses:Fees        12.40 USD
-  Assets:Investments  -12.40 USD
+  Expenses:Fees                12.40 USD
+  Assets:Investments:XXX:USD  -12.40 USD
 `,
 	} {
 		got := txs[i].String()

--- a/cmd/ofx2coin/README.md
+++ b/cmd/ofx2coin/README.md
@@ -12,7 +12,7 @@ Converts OFX/QFX files into coin transactions
 
 ## ofx.rules
 
-The file contains groupes of rules, one rule per line. The groups are associated either with a specific account or with a label that can be used to include that group in other groups to allow sharing of rules between accounts.
+The file contains groups of rules, one rule per line. The groups are associated either with a specific account or with a label that can be used to include that group in other groups to allow sharing of rules between accounts.
 
 When importing transactions for given account the tool will apply the rule group associated with that account. The account is matched through the account ID associated with the transactions. The same ID must also be associated with an account through the `ofx_acctid` directive.
 
@@ -20,7 +20,7 @@ Each rule group starts with a line containing either a label, or an account ID a
 
 A group reference is simply a group name prefixed with `@`. Referencing a group includes all the rules of the referenced group in the referencing group.
 
-A rule is a full account name followed by a list of regular expressions separated with `|`. The rules and regular expressions are matched against transaction descriptions in the order in which they are listed. The search stops on the first match and the corresponing account is used as the transaction counterpart of the imported account.
+A rule is a full account name followed by a list of regular expressions separated with `|`. The rules and regular expressions are matched against transaction descriptions in the order in which they are listed. The search stops on the first match and the corresponding account is used as the transaction counterpart of the imported account.
 
 ```
 common
@@ -34,7 +34,7 @@ common
   Income:Salary       ACME PAY 
 ```
 
-## Sugested Import Procedure
+## Suggested Import Procedure
 
 * assuming we're working in the directory where the coin files are located
     `cd $COINDB`


### PR DESCRIPTION
Fixes a few small issues around finding sub-accounts based on amount/quantity commodities. Also gets rid of the `CSVAcctId` which was redundant, the mapping between the imported account ID and the corresponding account is already provided by the rules.