### PR TITLE
Add tagging for transactions and postings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceFolder}/cmd/coin",
-            "args": ["test", "${file}"],
+            "args": ["test", "-v", "${file}"],
         }
     ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Martin Kobetic
+Copyright (c) 2023 Martin Kobetic
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NB:** This is still a work in progress, a lot of information is missing and is filled in gradually.
+**NB:** This is still a work in progress, a lot of information is missing and is filled in gradually. There isn't much in terms of user documentation, but most features follow the same pattern as ledger-cli. You can learn most things from ledger-cli's excellent documentation.
 
 Coin is a heavily simplified offshoot of [ledger-cli.org](https://www.ledger-cli.org/). The idea of [plain text accounting](https://plaintextaccounting.org/) is brilliant, and ledger implements it beautifully. However ledger makes certain fundamental tradeoffs that have implications that some may find undesirable. For example its extreme flexibility in how amounts and commodities can be written (prefix/postfix/symbolic etc) forces commodities that include numbers to be quoted. That gets annoying when your ledger includes a lot of mutual fund names. Coin sacrifices this flexibility to avoid quoting.
 
@@ -105,10 +105,14 @@ For example the following expressions could match account `Assets:Investments:Br
 
 * only date, code, description/payee, and note/comment is recognized in transaction header
 * only account, quantity and optional balance is recognized in any transaction posting
-* posting note/comment is supported as well 
-
+* posting note/comment is supported as well
+* any combination of 'short notes' (appended at the end of the transaction or posting line)
+  and 'long notes' on separate lines following the transaction or posting line is possible
+* tags are parsed out of notes, simple tag #key or value tags #key: some value, are supported
 
 ## Implementation Notes
 
 * Amount is implemented as big.Int plus number of decimal places. Computations are truncated to the specified number of decimal places at every step.
 * Amount always includes Commodity
+* Everything is loaded into memory on start, so there is a theoretical limit on the total size of data.
+* Trying to keep dependencies to a minimum

--- a/cmd/coin/tags.go
+++ b/cmd/coin/tags.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/mkobetic/coin"
+)
+
+func init() {
+	(&cmdTags{}).newCommand("tags")
+}
+
+type cmdTags struct {
+	flagsWithUsage
+	values bool
+}
+
+func (*cmdTags) newCommand(names ...string) command {
+	var cmd cmdTags
+	cmd.FlagSet = newCommand(&cmd, names...)
+	setUsage(cmd.FlagSet, `tags [flags] [NAMEREX]
+
+List tags matching the NAMEREX.`)
+	cmd.BoolVar(&cmd.values, "v", false, "print tag values if applicable")
+	return &cmd
+}
+
+func (cmd *cmdTags) init() {
+	coin.LoadAll()
+}
+
+func (cmd *cmdTags) execute(f io.Writer) {
+	var nrex *regexp.Regexp
+	if cmd.NArg() > 0 {
+		nrex = regexp.MustCompile(cmd.Arg(0))
+	}
+	results := make(map[string][]string)
+	for _, t := range coin.Transactions {
+		collectKeys(nrex, t.Tags, results)
+		for _, p := range t.Postings {
+			collectKeys(nrex, p.Tags, results)
+		}
+	}
+	for _, k := range sortAndClean(results) {
+		vs := strings.Join(results[k], `", "`)
+		colon := ""
+		if len(vs) > 0 {
+			colon = ":"
+		}
+		if cmd.values && len(vs) > 0 {
+			fmt.Fprintf(f, `%s%s "%s"`+"\n", k, colon, vs)
+		} else {
+			fmt.Fprintf(f, "%s%s\n", k, colon)
+		}
+	}
+}
+
+func sortAndClean(results map[string][]string) (keys []string) {
+	for k := range results {
+		keys = append(keys, k)
+		results[k] = clean(results[k])
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func clean(list []string) []string {
+	sort.Strings(list)
+	if len(list[0]) == 0 {
+		return list[1:]
+	}
+	return list
+}
+
+func collectKeys(nrex *regexp.Regexp, tags coin.Tags, results map[string][]string) {
+	for k, v := range tags {
+		if nrex == nil || nrex.MatchString(k) {
+			results[k] = add(results[k], v)
+		}
+	}
+}
+
+func add(list []string, key string) []string {
+	for _, v := range list {
+		if v == key {
+			return list
+		}
+	}
+	return append(list, key)
+}

--- a/cmd/coin/test.go
+++ b/cmd/coin/test.go
@@ -42,6 +42,7 @@ func (cmd *cmdTest) execute(f io.Writer) {
 		return
 	}
 	lastTestFile := file(coin.Tests[0])
+	success := true
 	for _, t := range coin.Tests {
 		var args []string
 		scanner := bufio.NewScanner(strings.NewReader(t.Cmd))
@@ -78,6 +79,7 @@ func (cmd *cmdTest) execute(f io.Writer) {
 			lastTestFile = testFile
 			continue
 		}
+		success = false
 		fmt.Fprintf(f, "FAIL %s %s\n", t.Location(), t.Cmd)
 		difflib.WriteUnifiedDiff(f,
 			difflib.UnifiedDiff{
@@ -89,7 +91,11 @@ func (cmd *cmdTest) execute(f io.Writer) {
 			})
 	}
 	if !cmd.verbose {
-		fmt.Fprintf(f, "OK %s\n", lastTestFile)
+		result := "OK"
+		if !success {
+			result = "FAIL"
+		}
+		fmt.Fprintf(f, "%s %s\n", result, lastTestFile)
 	}
 }
 

--- a/posting.go
+++ b/posting.go
@@ -8,6 +8,7 @@ import (
 
 type Posting struct {
 	Notes []string
+	Tags  Tags
 
 	Transaction     *Transaction
 	Account         *Account

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,38 @@
+package coin
+
+import "regexp"
+
+var tagREX = regexp.MustCompile(`#(?P<key>\w+)(:\s*(?P<value>[^,]+\S)\s*(,|$))?`)
+var tagREXKey = tagREX.SubexpIndex("key")
+var tagREXValue = tagREX.SubexpIndex("value")
+
+type Tags map[string]string
+
+func parseTags(lines []string) Tags {
+	tags := make(Tags)
+	for _, line := range lines {
+		for _, match := range tagREX.FindAllStringSubmatch(line, -1) {
+			key, value := match[tagREXKey], match[tagREXValue]
+			tags[key] = value
+		}
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	return tags
+}
+
+func (t Tags) Includes(key string) bool {
+	if t == nil {
+		return false
+	}
+	_, ok := t[key]
+	return ok
+}
+
+func (t Tags) Value(key string) string {
+	if t == nil {
+		return ""
+	}
+	return t[key]
+}

--- a/tags.go
+++ b/tags.go
@@ -1,6 +1,9 @@
 package coin
 
-import "regexp"
+import (
+	"regexp"
+	"sort"
+)
 
 var tagREX = regexp.MustCompile(`#(?P<key>\w+)(:\s*(?P<value>[^,]+\S)\s*(,|$))?`)
 var tagREXKey = tagREX.SubexpIndex("key")
@@ -8,7 +11,7 @@ var tagREXValue = tagREX.SubexpIndex("value")
 
 type Tags map[string]string
 
-func parseTags(lines []string) Tags {
+func ParseTags(lines ...string) Tags {
 	tags := make(Tags)
 	for _, line := range lines {
 		for _, match := range tagREX.FindAllStringSubmatch(line, -1) {
@@ -20,6 +23,18 @@ func parseTags(lines []string) Tags {
 		return nil
 	}
 	return tags
+}
+
+func (t Tags) Has(rex *regexp.Regexp) bool {
+	if t == nil {
+		return false
+	}
+	for k := range t {
+		if rex.MatchString(k) {
+			return true
+		}
+	}
+	return false
 }
 
 func (t Tags) Includes(key string) bool {
@@ -35,4 +50,12 @@ func (t Tags) Value(key string) string {
 		return ""
 	}
 	return t[key]
+}
+
+func (t Tags) Keys() (keys []string) {
+	for k := range t {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/tags.go
+++ b/tags.go
@@ -28,18 +28,6 @@ func ParseTags(lines ...string) Tags {
 	return tags
 }
 
-func (t Tags) Has(rex *regexp.Regexp) bool {
-	if t == nil {
-		return false
-	}
-	for k := range t {
-		if rex.MatchString(k) {
-			return true
-		}
-	}
-	return false
-}
-
 func (t Tags) Includes(key string) bool {
 	if t == nil {
 		return false

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,38 @@
+package coin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mkobetic/coin/assert"
+)
+
+func Test_ParseTags(t *testing.T) {
+	for i, test := range []struct {
+		line string
+		tags string
+	}{
+		{
+			line: "hello #foo hi",
+			tags: `map[foo:]`,
+		},
+		{
+			line: "hello #foo:   hi ho   ",
+			tags: `map[foo:hi ho]`,
+		},
+		{
+			line: "#foo: hi, #bar there #baz: and now what",
+			tags: `map[bar: baz:and now what foo:hi]`,
+		},
+		{
+			line: "hello #foo: hi, #bar: there, #baz: now",
+			tags: `map[bar:there baz:now foo:hi]`,
+		},
+	} {
+		t.Run(fmt.Sprintf("%d %s", i, test.line), func(t *testing.T) {
+			tags := parseTags([]string{test.line})
+			out := fmt.Sprintf("%v", tags)
+			assert.Equal(t, test.tags, out)
+		})
+	}
+}

--- a/tags_test.go
+++ b/tags_test.go
@@ -30,7 +30,7 @@ func Test_ParseTags(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%d %s", i, test.line), func(t *testing.T) {
-			tags := parseTags([]string{test.line})
+			tags := ParseTags(test.line)
 			out := fmt.Sprintf("%v", tags)
 			assert.Equal(t, test.tags, out)
 		})

--- a/tests/cmd/bal/tags.test
+++ b/tests/cmd/bal/tags.test
@@ -1,0 +1,33 @@
+commodity CAD
+  format 1.00 CAD
+account AAA
+account BBB
+account CCC
+
+2020 bob ; #two
+  AAA 1 CAD
+  BBB
+
+2020 joe
+  AAA 2 CAD; hi
+  BBB ; #one: and only
+
+2020 fred
+  BBB 3 CAD; #one: nope
+  CCC
+
+2020 bud ; #one: only this time
+  BBB 4 CAD
+  AAA
+
+test bal -t one:only
+ 0.00 | -2.00 CAD | Root
+-4.00 | -4.00 CAD | AAA
+ 2.00 |  2.00 CAD | BBB
+end test
+
+test bal -t one
+ 0.00 |  1.00 CAD | Root
+-4.00 | -4.00 CAD | AAA
+ 5.00 |  5.00 CAD | BBB
+end test

--- a/tests/cmd/mod/tags.test
+++ b/tests/cmd/mod/tags.test
@@ -1,0 +1,24 @@
+commodity CAD
+  format 1.00 CAD
+account AAA
+account BBB
+account CCC
+
+2020 bob ; #two
+  AAA 1 CAD
+  BBB
+
+2020 joe
+  AAA 2 CAD; hi
+  BBB ; #one: and only
+
+test mod -tt two -a BBB -pt: #bar:baz
+2020/01/01 bob ; #two
+  AAA   1.00 CAD
+  BBB  -1.00 CAD ; #bar:baz
+
+2020/01/01 joe
+  AAA   2.00 CAD ; hi
+  BBB  -2.00 CAD ; #one: and only
+
+end test

--- a/tests/cmd/reg/tags.test
+++ b/tests/cmd/reg/tags.test
@@ -1,0 +1,34 @@
+commodity CAD
+  format 1.00 CAD
+account AAA
+account BBB
+account CCC
+
+2020 bob ; #two
+  AAA 1 CAD
+  BBB
+
+2020 joe
+  AAA 2 CAD; hi
+  BBB ; #one: and only
+
+2020 fred
+  BBB 3 CAD; #one: nope
+  CCC
+
+2020 bud ; #one: only this time
+  BBB 4 CAD
+  AAA
+
+test reg -t one:only BBB
+BBB CAD
+2020/01/01 | joe | AAA | -2.00 | -2.00 CAD 
+2020/01/01 | bud | AAA |  4.00 | 2.00 CAD 
+end test
+
+test reg -t one BBB
+BBB CAD
+2020/01/01 |  joe | AAA | -2.00 | -2.00 CAD 
+2020/01/01 | fred | CCC |  3.00 | 1.00 CAD 
+2020/01/01 |  bud | AAA |  4.00 | 5.00 CAD 
+end test

--- a/tests/cmd/tags/basic.test
+++ b/tests/cmd/tags/basic.test
@@ -1,0 +1,25 @@
+commodity CAD
+  format 1.00 CAD
+account AAA
+account BBB
+account CCC
+
+2020 bob #none ; one #two
+  AAA 1 CAD
+  BBB ; #two
+
+2020 joe ; #three:     a ok
+  AAA 2 CAD; hi
+    ; ho #three: nope, whatever
+  BBB ; #one: and only
+
+test tags
+one:
+three:
+two
+end test
+
+test tags -v t
+three: "a ok", "nope"
+two
+end test

--- a/transaction.go
+++ b/transaction.go
@@ -186,9 +186,9 @@ func (p *Parser) parseTransaction(fn string) (*Transaction, error) {
 	if len(notes) > 0 {
 		s.Notes = append(s.Notes, notes...)
 	}
-	t.Tags = parseTags(t.Notes)
+	t.Tags = ParseTags(t.Notes...)
 	for _, p := range t.Postings {
-		p.Tags = parseTags(p.Notes)
+		p.Tags = ParseTags(p.Notes...)
 	}
 	return t, p.Err()
 }

--- a/transaction.go
+++ b/transaction.go
@@ -19,6 +19,7 @@ type Transaction struct {
 	Description string
 	Notes       []string
 	Postings    []*Posting
+	Tags        Tags
 
 	Posted time.Time
 
@@ -184,6 +185,10 @@ func (p *Parser) parseTransaction(fn string) (*Transaction, error) {
 	}
 	if len(notes) > 0 {
 		s.Notes = append(s.Notes, notes...)
+	}
+	t.Tags = parseTags(t.Notes)
+	for _, p := range t.Postings {
+		p.Tags = parseTags(p.Notes)
 	}
 	return t, p.Err()
 }


### PR DESCRIPTION
This is a variation of [hledger tags and tag values](https://hledger.org/1.31/hledger.html#tags), but instead of colon suffix it uses a hash prefix like [beancount tags](https://beancount.github.io/docs/beancount_language_syntax.html#tags). [Ledger tags](https://ledger-cli.org/doc/ledger3.html#Metadata-tags) feel a bit odd, so this marks a definitive departure from any pretense of ledger compatibility (should probably get rid of the ledger flag throughout).

Tags are parsed out of notes. A tag is either a simple tag `#key` or a value tag `#key: a value`.  A tag value is terminated either by a comma or end of line, leading/trailing whitespace is trimmed off.

Several commands (balance, register, modify) allow filtering transactions/postings by a tag expression, which is either one or two regexes separated by a colon, that are matched against tag keys of values respectively.