### PR TITLE
ofx2coin, csv2coin: tagging imported transactions

### DIFF
--- a/cmd/csv2coin/main.go
+++ b/cmd/csv2coin/main.go
@@ -119,9 +119,11 @@ func transactionFrom(row []string, fields map[string]Fields, allRules *Rules) *c
 	rules := allRules.AccountRulesFor(acctId)
 	check.If(rules != nil, "Can't find rules for account id %s", acctId)
 	account := rules.Account
-	toAccount := rules.AccountFor(description)
-	if toAccount == nil {
-		toAccount = coin.Unbalanced
+	toAccount := coin.Unbalanced
+	var notes []string
+	if rule := rules.RuleFor(description); rule != nil {
+		toAccount = rule.Account
+		notes = rule.Notes
 	}
 
 	date := valueFor("date")
@@ -131,6 +133,7 @@ func transactionFrom(row []string, fields map[string]Fields, allRules *Rules) *c
 	t := &coin.Transaction{
 		Description: description,
 		Posted:      posted,
+		Notes:       notes,
 	}
 
 	if n := trim(valueFor("note")); len(n) > 0 {

--- a/cmd/ofx2coin/README.md
+++ b/cmd/ofx2coin/README.md
@@ -22,6 +22,8 @@ A group reference is simply a group name prefixed with `@`. Referencing a group 
 
 A rule is a full account name followed by a list of regular expressions separated with `|`. The rules and regular expressions are matched against transaction descriptions in the order in which they are listed. The search stops on the first match and the corresponding account is used as the transaction counterpart of the imported account.
 
+A rule can also be followed by one or more note lines (space offset and prefixed with semicolon), which will be also automatically applied to all matching transactions. This can be used for tagging.
+
 ```
 common
   Expenses:Groceries       FRESHCO|COSTCO WHOLESALE|FARM BOY|LOBLAWS

--- a/cmd/ofx2coin/main.go
+++ b/cmd/ofx2coin/main.go
@@ -168,9 +168,12 @@ func readTransactions(r io.Reader, rules *coin.RuleIndex) (transactions []*coin.
 
 func newTransaction(ars *coin.AccountRules, date time.Time, payee string, amount big.Rat, balance *big.Rat) *coin.Transaction {
 	from := ars.Account
-	to := ars.AccountFor(payee)
-	if to == nil {
-		to = coin.Unbalanced
+	to := coin.Unbalanced
+	var notes []string
+	rule := ars.RuleFor(payee)
+	if rule != nil {
+		to = rule.Account
+		notes = rule.Notes
 	}
 	amt := coin.NewAmountFrac(amount.Num(), amount.Denom(), ars.Account.Commodity)
 	var bal *coin.Amount
@@ -179,7 +182,9 @@ func newTransaction(ars *coin.AccountRules, date time.Time, payee string, amount
 	}
 	t := &coin.Transaction{
 		Posted:      date,
-		Description: payee}
+		Description: payee,
+		Notes:       notes,
+	}
 	t.Post(from, to, amt, bal)
 	return t
 }

--- a/rules_test.go
+++ b/rules_test.go
@@ -40,6 +40,7 @@ common
 	Income:Salary       ACME PAY 
 479347938749398 Liabilities:Credit:MC
   Expenses:Auto            HUYNDAI|TOYOTA
+  ; service/maintenance
   @common
   Expenses:Miscellaneous   
 `
@@ -52,6 +53,10 @@ func Test_ReadRules(t *testing.T) {
 	mc := rules.Accounts["479347938749398"]
 	assert.NotNil(t, mc)
 	assert.Equal(t, len(mc.Rules), 3)
+	r1, ok := mc.Rules[0].(*Rule)
+	assert.True(t, ok)
+	assert.Equal(t, len(r1.Notes), 1)
+	assert.Equal(t, r1.Notes[0], "service/maintenance")
 }
 
 func Test_Classification(t *testing.T) {
@@ -66,7 +71,9 @@ func Test_Classification(t *testing.T) {
 		{"479347938749398", "[TR] COSTCO WHOLESALE #9239", "Expenses:Groceries"},
 		{"479347938749398", "JOE'S DINER", "Expenses:Miscellaneous"},
 	} {
-		account := rules.AccountRulesFor(fix.from).AccountFor(fix.payee)
+		rule := rules.AccountRulesFor(fix.from).RuleFor(fix.payee)
+		assert.NotNil(t, rule)
+		account := rule.Account
 		if account.FullName != fix.to {
 			t.Errorf("mismatched\nexp: %s\ngot: %s\n", fix.to, account.FullName)
 		}


### PR DESCRIPTION
Allow optional notes on import rules, which will be automatically applied to all matching transactions. Notes can include tags as well. One or more note lines must follow the rule line immediately. 