### PR TITLE
ofx2coin: add support for drop rules

### DIFF
--- a/cmd/ofx2coin/main_test.go
+++ b/cmd/ofx2coin/main_test.go
@@ -51,6 +51,10 @@ func Test_Classification(t *testing.T) {
 			t.Errorf("mismatched\nexp: %s\ngot: %s\n", fix.to, account)
 		}
 	}
+	whatever := newTransaction(rules.Accounts["479347938749398"], date, "TO BE IGNORED WHEN WHATEVER", *big.NewRat(-10000, 100), nil)
+	if whatever != nil {
+		t.Error("should be nil")
+	}
 }
 
 func Test_ReadTransactions(t *testing.T) {
@@ -58,6 +62,16 @@ func Test_ReadTransactions(t *testing.T) {
 	r = strings.NewReader(sample)
 	rules, err := coin.ReadRules(r)
 	assert.NoError(t, err)
+	mc := rules.SetsByName["common"]
+	assert.NotNil(t, mc)
+	assert.Equal(t, len(mc.Rules), 3)
+	drop := mc.Rules[2].(*coin.Rule)
+	if drop.Account != nil {
+		t.Error("should be nil")
+	}
+	assert.True(t, drop.Match([]byte("TO BE IGNORED WHEN WHATEVER")))
+	assert.Equal(t, len(drop.Notes), 1)
+	assert.Equal(t, drop.Notes[0], "payee with WHATEVER in it will be ignored")
 
 	r = strings.NewReader(txsSample)
 	r = newBMOReader(r)
@@ -116,6 +130,8 @@ var sample = `
 common
   Expenses:Groceries       FRESHCO|COSTCO WHOLESALE|FARM BOY|LOBLAWS
   Expenses:Auto:Gas        COSTCO GAS|PETROCAN|SHELL
+  -- WHATEVER
+  ; payee with WHATEVER in it will be ignored
 389249328477983 Assets:Bank:Savings
   Income:Interest     Interest
 392843029797099 Assets:Bank:Checking

--- a/rules.go
+++ b/rules.go
@@ -192,8 +192,12 @@ func ScanRules(line []byte, s *bufio.Scanner) (*RuleIndex, error) {
 					break
 				}
 				if len(match[1]) > 0 {
+					var account *Account
+					if string(match[1]) != "--" {
+						account = MustFindAccount(string(match[1]))
+					}
 					lastRule = &Rule{
-						Account: MustFindAccount(string(match[1])),
+						Account: account,
 						Regexp:  regexp.MustCompile(string(match[3]))}
 					rules = append(rules, lastRule)
 				} else if len(match[4]) > 0 {


### PR DESCRIPTION
Adds the ability to specify import rules that drop the transaction. A drop rule uses `--` as the account pattern, e.g.
```
  -- WHATEVER
  ; transaction that has payee with WHATEVER in it will be dropped
  ; may want to add an explanation why as a rule note for future reference
```