### PR TITLE
fix conversion issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
   },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+  "makefile.configureOnOpen": false
 }

--- a/TODO.md
+++ b/TODO.md
@@ -24,15 +24,16 @@
 
 ### coin2html
 
-- make commodity conversions more robust, they blow up too easily
-- replace dateToString with d3.format
-- tooltips for columns, inputs and wherever useful
+- allow dropping subaccounts from aggregations (in both chart and register)
 - show details of selected posting
 - show details of selected posting group
 - filter subaccounts, payee, tag...
+- replace dateToString with d3.format
+- try d3 binning for groupBy utils
+- try d3 layouts
+- tooltips for columns, inputs and wherever useful
 - preserve UI state in history (make back/forward buttons work)
 - trim to time range on export (need to recalc posting balances!)
-- allow dropping a subaccount from aggregations (in both chart and register)
 - balance charts
 - show commodities and prices
 - investment performance summary

--- a/cmd/coin2html/js/body.html
+++ b/cmd/coin2html/js/body.html
@@ -22,7 +22,10 @@
       >
     </section>
     <h1>
-      <output id="account"></output>
+      <output id="account">
+        <span id="name"></span>
+        <span id="commodity"></span>
+      </output>
     </h1>
     <section id="view"></section>
   </section>

--- a/cmd/coin2html/js/spec/commodity.spec.ts
+++ b/cmd/coin2html/js/spec/commodity.spec.ts
@@ -1,10 +1,23 @@
-import { Amount, Commodity } from "../src/commodity";
+import {
+  Amount,
+  Commodities,
+  commodity,
+  Commodity,
+  composeConversions,
+  newConversion,
+  Price,
+} from "../src/commodity";
 
-test("create commodity", () =>
-  expect(new Commodity("CAD", "Canadian Dollar", 2, "")).toBeTruthy());
+for (const [id, decimals] of Object.entries({
+  USD: 2,
+  CAD: 2,
+  EUR: 2,
+  CZK: 2,
+}))
+  if (!Commodities[id]) Commodities[id] = new Commodity(id, id, decimals, "");
 
 describe("amount", () => {
-  const CAD = new Commodity("CAD", "Canadian Dollar", 2, "");
+  const CAD = commodity`CAD`;
   test.each([
     [0, "0.00 CAD"],
     [1, "0.01 CAD"],
@@ -13,8 +26,119 @@ describe("amount", () => {
     [-50, "-0.50 CAD"],
     [123456789, "1,234,567.89 CAD"],
     [-12345678, "-123,456.78 CAD"],
-  ])(`%#: %i`, (i, expected) => {
+  ])(`%#: toString %i`, (i, expected) => {
     const amt = new Amount(i, CAD);
     expect(amt.toString()).toBe(expected);
+  });
+
+  test.each([
+    ["25.00 CAD", "25.00 CAD"],
+    ["25.0 CAD", "25.00 CAD"],
+    ["25 CAD", "25.00 CAD"],
+    ["-25 CAD", "-25.00 CAD"],
+    ["0.1 CAD", "0.10 CAD"],
+    ["-0.02834 CAD", "-0.02 CAD"],
+    ["25.0330 CAD", "25.03 CAD"],
+    ["25,033.5 CAD", "25,033.50 CAD"],
+  ])(`%#: parse %s`, (input, expected) => {
+    expect(Amount.parse(input).toString()).toBe(expected);
+  });
+
+  test.each([
+    ["4 CAD", 4, 2500],
+    ["0.25 CAD", 4, 40000],
+    ["4 CAD", 2, 25],
+    ["0.25 CAD", 2, 400],
+  ])(`%#: reciprocal %s/%d`, (input, decimals, expected) => {
+    expect(Amount.parse(input).reciprocal(decimals)).toBe(expected);
+  });
+});
+
+describe("price", () => {
+  test.each([
+    ["CAD: 0.75 USD @ 2000-01-01"],
+    ["USD: 1.33 CAD @ 2000-01-01"],
+    ["USD: 0.99 EUR @ 2010-01-01"],
+  ])("toString %s", (input) => {
+    const price = Price.parse(input);
+    expect(price.toString()).toBe(input);
+  });
+  test.each([
+    ["CAD: 0.75 USD", "USD: 1.33 CAD"],
+    ["USD: 1.33 CAD", "CAD: 0.75 USD"],
+  ])("reverse %s", (input, expected) => {
+    const price = Price.parse(input);
+    const reversed = price.reverse().toString().split("@")[0].trim();
+    expect(reversed).toBe(expected);
+  });
+});
+
+describe("conversions", () => {
+  test("composition", () => {
+    const day = new Date("2000-01-01");
+    const dayString = day.toISOString().split("T")[0];
+    const cu = newConversion([Price.parse(`CAD: 0.75 USD @ ${dayString}`)]);
+    const ue = newConversion([Price.parse(`USD: 0.90 EUR @ ${dayString}`)]);
+    const ce = composeConversions(cu, ue);
+    expect(ce.direction).toBe("CAD => USD => EUR");
+    expect(ce(day).toString()).toBe("CAD: 0.68 EUR @ 2000-01-01");
+    expect(() => composeConversions(ue, cu)).toThrow();
+
+    const ez = newConversion([Price.parse(`EUR: 25.00 CZK @ ${dayString}`)]);
+    const cz = composeConversions(cu, composeConversions(ue, ez));
+    expect(cz.direction).toBe("CAD => USD => EUR => CZK");
+    expect(cz(day).toString()).toBe("CAD: 16.88 CZK @ 2000-01-01");
+  });
+
+  describe("amount conversions", () => {
+    const CAD = new Commodity("CAD", "CAD", 2, "");
+    const USD = new Commodity("USD", "USD", 2, "");
+    const EUR = new Commodity("EUR", "EUR", 2, "");
+    const CZK = new Commodity("CZK", "CZK", 2, "");
+    const day = new Date("2000-01-01");
+    for (const [com, val, com2] of [
+      [CAD, 75, USD],
+      [USD, 90, EUR],
+      [EUR, 2500, CZK],
+      [CAD, 68, EUR],
+    ] as [Commodity, number, Commodity][]) {
+      const p = new Price(com, day, new Amount(val, com2), "");
+      com.prices.push(p);
+      com2.prices.push(p.reverse());
+    }
+    test.each([
+      [350, CAD, 350, USD, "8.16 CAD"],
+      [350, USD, 350, CAD, "6.13 USD"],
+      [350, EUR, 350, USD, "6.65 EUR"],
+      [350, USD, 350, EUR, "7.39 USD"],
+      [350, EUR, 3500, CZK, "4.90 EUR"],
+      [3500, CZK, 350, EUR, "122.50 CZK"],
+      [350, CAD, 350, EUR, "8.65 CAD"],
+      [350, EUR, 350, CAD, "5.88 EUR"],
+      [3500, CZK, 350, CAD, "94.50 CZK"],
+      [3500, CZK, 350, USD, "113.75 CZK"],
+      [350, CAD, 3500, CZK, "5.60 CAD"],
+      [350, USD, 3500, CZK, "4.90 USD"],
+    ])(`%#: %d %s + %d %s`, (fv, fc, tv, tc, exp) => {
+      expect(new Amount(fv, fc).addIn(new Amount(tv, tc), day).toString()).toBe(
+        exp
+      );
+    });
+    test.each([
+      [CAD, CZK, "17.00 CZK"],
+      [USD, CZK, "22.50 CZK"],
+      [CZK, USD, "0.04 USD"],
+      [CZK, CAD, "0.06 CAD"],
+    ])(`%#: %s -> %s`, (from, to, exp) => {
+      expect(to.convert(new Amount(100, from), day).toString()).toBe(exp);
+    });
+    test.each([
+      [CAD, ["CAD => USD", "CAD => EUR", "CAD => EUR => CZK"]],
+      [USD, ["USD => CAD", "USD => EUR", "USD => EUR => CZK"]],
+      [EUR, ["EUR => USD", "EUR => CZK", "EUR => CAD"]],
+      [CZK, ["CZK => EUR", "CZK => EUR => CAD", "CZK => EUR => USD"]],
+    ])(`%#: %s conversions`, (c, exp) => {
+      expect([...c.conversions.values()].map((c) => c.direction)).toEqual(exp);
+    });
   });
 });

--- a/cmd/coin2html/js/src/account.ts
+++ b/cmd/coin2html/js/src/account.ts
@@ -1,4 +1,4 @@
-import { Amount, Commodities, Commodity } from "./commodity";
+import { Amount, Commodity } from "./commodity";
 import { State } from "./views";
 import {
   AccountPostingGroups,
@@ -6,6 +6,10 @@ import {
   groupBy,
   trimToDateRange,
 } from "./utils";
+
+/**
+ *  Account, Posting and Transaction
+ */
 
 export class Account {
   children: Account[] = [];
@@ -166,17 +170,15 @@ export let MaxDate = new Date(0);
 
 export const Accounts: Record<string, Account> = {};
 export const Roots: Account[] = [];
-export function loadAccounts() {
-  const importedAccounts = JSON.parse(
-    document.getElementById("importedAccounts")!.innerText
-  ) as importedAccounts;
+export function loadAccounts(source: string) {
+  const importedAccounts = JSON.parse(source) as importedAccounts;
   for (const impAccount of Object.values(importedAccounts)) {
     if (impAccount.name == "Root") continue;
     const parent = Accounts[impAccount.parent];
     const account = new Account(
       impAccount.name,
       impAccount.fullName,
-      Commodities[impAccount.commodity],
+      Commodity.find(impAccount.commodity),
       parent,
       impAccount.location,
       impAccount.closed ? new Date(impAccount.closed) : undefined
@@ -186,10 +188,10 @@ export function loadAccounts() {
       Roots.push(account);
     }
   }
+}
 
-  const importedTransactions = JSON.parse(
-    document.getElementById("importedTransactions")!.innerText
-  ) as importedTransactions;
+export function loadTransactions(source: string) {
+  const importedTransactions = JSON.parse(source) as importedTransactions;
   for (const impTransaction of Object.values(importedTransactions)) {
     const posted = new Date(impTransaction.posted);
     if (posted < MinDate) MinDate = posted;

--- a/cmd/coin2html/js/src/commodity.ts
+++ b/cmd/coin2html/js/src/commodity.ts
@@ -5,40 +5,92 @@ import { dateToString, last } from "./utils";
 // Commodity, Amount and Price
 
 // Conversion produces price from date.
-type Conversion = (d: Date) => Amount;
+type Conversion = {
+  (d: Date): Price;
+  from: Commodity;
+  to: Commodity;
+  direction: string;
+  steps: number;
+};
 
-function newConversion(prices: Price[]): Conversion {
-  if (prices.length == 0)
+export function newConversion(knownPrices: Price[]): Conversion {
+  // knownPrices are assumed to be sorted by time
+  if (knownPrices.length == 0)
     throw new Error("cannot create conversion from empty price list");
-  const from = prices[0].date;
-  const to = last(prices)!.date;
+  const from = knownPrices[0].date;
+  const to = last(knownPrices)!.date;
   const dates = timeWeek.range(from, to);
-  if (dates.length == 0) return (d: Date) => prices[0].value;
-  // scale from dates to the number of weeks/price points
+  const params = {
+    from: knownPrices[0].commodity,
+    to: knownPrices[0].value.commodity,
+    dates,
+    direction: knownPrices[0].direction,
+    steps: 1,
+  };
+  if (dates.length == 0) {
+    return Object.assign((d: Date) => knownPrices[0], params);
+  }
+  // scale from dates to the index of the week in the date range
   const scale = scaleTime([from, to], [0, dates.length - 1]).clamp(true);
-  // generate array of prices per week
+  // generate array of weekly prices
   let cpi = 0;
-  const weeks = dates.map((d) => {
-    while (prices[cpi].date < d) cpi++;
-    return prices[cpi].value;
+  const weeklyPrices = dates.map((d) => {
+    while (knownPrices[cpi].date < d) cpi++;
+    return knownPrices[cpi];
   });
   // conversion function, add closed over elements as properties for debugging
-  const conversion = (d: Date) => weeks[Math.round(scale(d))];
-  conversion.scale = scale;
-  conversion.weeks = weeks;
-  conversion.dates = dates;
-  return conversion;
+  const conversion = (d: Date) => weeklyPrices[Math.round(scale(d))];
+
+  return Object.assign(conversion, {
+    scale,
+    weeks: weeklyPrices,
+    ...params,
+  });
+}
+
+export function composeConversions(
+  conversion: Conversion,
+  conversion2: Conversion
+) {
+  if (conversion.steps > 1 || conversion.to != conversion2.from)
+    throw new Error(
+      `cannot compose conversions ${conversion.direction} and ${conversion2.direction}`
+    );
+  return Object.assign(
+    (d: Date) =>
+      new Price(
+        conversion.from,
+        d,
+        conversion(d).value.convertTo(conversion2(d)),
+        ""
+      ),
+    {
+      from: conversion.from,
+      to: conversion2.to,
+      direction: conversion.from.toString() + " => " + conversion2.direction,
+      conversion,
+      conversion2,
+      steps: conversion.steps + conversion2.steps,
+    }
+  );
 }
 
 export class Commodity {
   prices: Price[] = [];
   _conversions?: Map<Commodity, Conversion>;
+
   constructor(
     readonly id: string,
     readonly name: string,
     readonly decimals: number,
     readonly location: string
   ) {}
+
+  static find(id: string): Commodity {
+    const c = Commodities[id];
+    if (!c) throw new Error(`unknown commodity ${id}`);
+    return c;
+  }
   toString(): string {
     return this.id;
   }
@@ -47,25 +99,54 @@ export class Commodity {
   get conversions() {
     if (this._conversions) return this._conversions;
     // group prices by price commodity
-    const prices = new Map<Commodity, Price[]>();
+    const pricesByCommodity = new Map<Commodity, Price[]>();
+    // make sure the prices are sorted correctly
+    this.prices.sort((a, b) => a.date.getTime() - b.date.getTime());
     this.prices.forEach((p) => {
-      const cps = prices.get(p.value.commodity);
+      const cps = pricesByCommodity.get(p.value.commodity);
       if (cps) cps.push(p);
-      else prices.set(p.value.commodity, [p]);
+      else pricesByCommodity.set(p.value.commodity, [p]);
     });
     // build a conversion function for each price commodity
     this._conversions = new Map();
-    for (const [commodity, cps] of prices) {
+    for (const [commodity, cps] of pricesByCommodity) {
       const conversion = newConversion(cps);
       this._conversions.set(commodity, conversion);
     }
     return this._conversions;
   }
+  findConversion(to: Commodity): Conversion | undefined {
+    function breadthFirstSearch(
+      queue: [Commodity, Conversion[]][], // path of conversions in reverse order
+      visited: Set<Commodity> // visited commodities
+    ): Conversion[] | undefined {
+      while (queue.length > 0) {
+        const [commodity, path] = queue.shift()!;
+        const conversion = commodity.conversions.get(to);
+        // cannot use multi-step conversions in the search because that won't yield shortest path
+        if (conversion && conversion.steps == 1) return [conversion, ...path];
+        for (const [commodity2, conversion] of commodity.conversions) {
+          if (conversion.steps > 1 || visited.has(commodity2)) continue;
+          queue.push([commodity2, [conversion, ...path]]);
+          visited.add(commodity2);
+        }
+      }
+      return undefined;
+    }
+    const path = breadthFirstSearch([[this, []]], new Set([this]));
+    if (!path) return undefined;
+    if (path.length == 1) return path[0];
+    return path.slice(1).reduce((previous, conversion) => {
+      const composed = composeConversions(conversion, previous);
+      composed.from._conversions!.set(composed.to, composed);
+      return composed;
+    }, path[0]);
+  }
+
   // convert amount to this commodity using price on given date
   convert(amount: Amount, date: Date): Amount {
-    if (amount.isZero) return new Amount(0, this);
-    if (amount.commodity == this) return amount;
-    const conversion = amount.commodity.conversions.get(this);
+    if (amount.commodity == this || amount.isZero) return new Amount(0, this);
+    const conversion = amount.commodity.findConversion(this);
     if (!conversion)
       throw new Error(
         `Cannot convert ${amount.toString()} to ${this.toString()}`
@@ -73,6 +154,14 @@ export class Commodity {
     const price = conversion(date);
     return amount.convertTo(price);
   }
+}
+
+export const Commodities: Record<string, Commodity> = {};
+// template parser, e.g. commodity`CAD`
+export function commodity(strings: TemplateStringsArray): Commodity {
+  if (strings.length != 1)
+    throw new Error(`invalid commodity template ${strings}`);
+  return Commodity.find(strings[0]);
 }
 
 export class Amount {
@@ -85,12 +174,20 @@ export class Amount {
     if (parts.length != 2) {
       throw new Error("Invalid amount: " + input);
     }
-    const commodity = Commodities[parts[1]];
-    if (!commodity) {
-      throw new Error("Unknown commodity: " + parts[1]);
+    const commodity = Commodity.find(parts[1]);
+
+    // drop the decimal point, make sure value aligns with commodity.decimals.
+    let [int, dec] = parts[0].split(".");
+    if (commodity.decimals > 0) {
+      if (!dec) dec = "";
+      dec =
+        dec.length > commodity.decimals
+          ? dec.slice(0, commodity.decimals)
+          : dec + "0".repeat(commodity.decimals - dec.length);
+      // drop thousands separators if present
+      int = int.replace(",", "") + dec;
     }
-    // drop the decimal point, commodity.decimals should indicate where it is.
-    const value = Number(parts[0].replace(".", ""));
+    const value = parseInt(int);
     return new Amount(value, commodity);
   }
   toString(thousandsSeparator = true): string {
@@ -120,17 +217,22 @@ export class Amount {
     }
     return this.addIn(this.commodity.convert(amount, date), date);
   }
-  convertTo(price: Amount): Amount {
+  convertTo(price: Price): Amount {
     // the product decimals is a sum of this and price decimals, so divide by this decimals
-    const float = (this.value * price.value) / 10 ** this.commodity.decimals;
+    const float =
+      (this.value * price.value.value) / 10 ** this.commodity.decimals;
     // accounting rounding should round 0.5 up
-    return new Amount(Math.round(float), price.commodity);
+    return new Amount(Math.round(float), price.value.commodity);
   }
   cmp(amount: Amount) {
     const decimalDiff = this.commodity.decimals - amount.commodity.decimals;
     return decimalDiff < 0
       ? this.value * 10 ** -decimalDiff - amount.value
       : this.value - amount.value * 10 ** decimalDiff;
+  }
+  reciprocal(decimals: number): number {
+    const reciprocal = 10 ** this.commodity.decimals / this.value;
+    return Math.round(reciprocal * 10 ** decimals);
   }
   get sign() {
     return Math.sign(this.value);
@@ -140,24 +242,61 @@ export class Amount {
   }
 }
 
+// template parser, e.g. amount`10.00 CAD`
+export function amount(strings: TemplateStringsArray): Amount {
+  if (strings.length != 1)
+    throw new Error(`invalid amount template ${strings}`);
+  return Amount.parse(strings[0]);
+}
+
 export class Price {
   constructor(
     readonly commodity: Commodity,
     readonly date: Date,
     readonly value: Amount,
     readonly location: string
-  ) {
-    commodity.prices.push(this);
+  ) {}
+  static parse(input: string): Price {
+    const parts = input.split(":");
+    if (parts.length != 2) {
+      throw new Error("Invalid price: " + input);
+    }
+    const commodity = Commodity.find(parts[0].trim());
+    const [value, dateString] = parts[1].split("@");
+    const date = dateString ? new Date(dateString.trim()) : new Date();
+    return new Price(commodity, date, Amount.parse(value.trim()), "unknown");
   }
+
   toString(): string {
     return (
       this.commodity.toString() +
       ": " +
       this.value.toString() +
-      "@" +
+      " @ " +
       dateToString(this.date)
     );
   }
+  reverse(): Price {
+    return new Price(
+      this.value.commodity,
+      this.date,
+      new Amount(
+        this.value.reciprocal(this.commodity.decimals),
+        this.commodity
+      ),
+      this.location
+    );
+  }
+  get direction() {
+    return this.commodity.toString() + " => " + this.value.commodity.toString();
+  }
+}
+
+// template parser, e.g. price`USD: 1.33 CAD`
+export function price(strings: TemplateStringsArray): Price {
+  if (strings.length != 1)
+    throw new Error(`invalid amount template ${strings}`);
+  return Price.parse(strings[0]);
 }
 
 type importedCommodities = Record<
@@ -166,17 +305,13 @@ type importedCommodities = Record<
 >;
 type importedPrices = {
   commodity: string;
-  currency: string;
   time: string;
   value: string;
   location: string;
 }[];
 
-export const Commodities: Record<string, Commodity> = {};
-export function loadCommodities() {
-  const importedCommodities = JSON.parse(
-    document.getElementById("importedCommodities")!.innerText
-  ) as importedCommodities;
+export function loadCommodities(source: string) {
+  const importedCommodities = JSON.parse(source) as importedCommodities;
   for (const impCommodity of Object.values(importedCommodities)) {
     const commodity = new Commodity(
       impCommodity.id,
@@ -186,16 +321,13 @@ export function loadCommodities() {
     );
     Commodities[commodity.id] = commodity;
   }
+}
 
-  const importedPrices = JSON.parse(
-    document.getElementById("importedPrices")!.innerText
-  ) as importedPrices;
+export function loadPrices(source: string) {
+  const importedPrices = JSON.parse(source) as importedPrices;
   if (importedPrices) {
     for (const imported of importedPrices) {
-      const commodity = Commodities[imported.commodity];
-      if (!commodity) {
-        throw new Error("Unknown commodity: " + imported.commodity);
-      }
+      const commodity = Commodity.find(imported.commodity);
       const amount = Amount.parse(imported.value);
       if (amount.toString(false) != imported.value) {
         throw new Error(
@@ -209,6 +341,7 @@ export function loadCommodities() {
         imported.location
       );
       commodity.prices.push(price);
+      amount.commodity.prices.push(price.reverse());
     }
   }
 }

--- a/cmd/coin2html/js/src/register.ts
+++ b/cmd/coin2html/js/src/register.ts
@@ -15,8 +15,9 @@ import { Account, Posting } from "./account";
 import {
   dateToString,
   groupBy,
-  groupWithSubAccounts,
+  groupByWithSubAccounts,
   last,
+  shortenAccountName,
   trimToDateRange,
 } from "./utils";
 import { Amount } from "./commodity";
@@ -125,13 +126,13 @@ function viewRegisterAggregatedWithSubAccounts(
   }
 ) {
   const dates = groupKey.range(State.StartDate, State.EndDate);
-  const groups = groupWithSubAccounts(
+  const groups = groupByWithSubAccounts(
     account,
     groupKey,
     State.View.AggregatedSubAccountMax,
     options
   );
-  // transpose the groups into row data
+  // convert the vertical groups into horizontal row data
   const total = new Amount(0, account.commodity);
   const data = dates.map((date, i) => {
     const balance = new Amount(0, account.commodity);
@@ -156,10 +157,13 @@ function viewRegisterAggregatedWithSubAccounts(
     });
     return row;
   });
+  const maxLabelLength = Math.round(150 / State.View.AggregatedSubAccountMax);
   const labels = [
     "Date",
     ...groups.map((g) =>
-      g.account ? account.relativeName(g.account) : "Other"
+      g.account
+        ? shortenAccountName(account.relativeName(g.account), maxLabelLength)
+        : "Other"
     ),
     "Total",
   ];
@@ -292,7 +296,7 @@ function viewRegisterFullWithSubAccounts(
       const values = [
         [dateToString(p.transaction.posted), "date"],
         [p.transaction.description, "text"],
-        [account.relativeName(p.account), "account"],
+        [shortenAccountName(account.relativeName(p.account), 30), "account"],
         [p.transaction.other(p).account, "account"],
         [p.quantity, "amount"],
         [Amount.clone(total), "amount"],

--- a/cmd/coin2html/js/src/ui.ts
+++ b/cmd/coin2html/js/src/ui.ts
@@ -2,12 +2,13 @@ import {
   Account,
   Accounts,
   loadAccounts,
+  loadTransactions,
   MaxDate,
   MinDate,
   Roots,
 } from "./account";
 import { dateToString } from "./utils";
-import { loadCommodities } from "./commodity";
+import { loadCommodities, loadPrices } from "./commodity";
 import {
   EndDateInput,
   RootAccountSelect,
@@ -22,8 +23,10 @@ import { select } from "d3-selection";
 
 function initializeUI() {
   // Need to load before initializing the UI state.
-  loadCommodities();
-  loadAccounts();
+  loadCommodities(document.getElementById("importedCommodities")!.innerText);
+  loadPrices(document.getElementById("importedPrices")!.innerText);
+  loadAccounts(document.getElementById("importedAccounts")!.innerText);
+  loadTransactions(document.getElementById("importedTransactions")!.innerText);
   State.SelectedAccount = Accounts.Assets;
   State.SelectedView = Object.keys(Views.Assets)[0];
   State.StartDate = MinDate;

--- a/cmd/coin2html/js/src/views.ts
+++ b/cmd/coin2html/js/src/views.ts
@@ -3,6 +3,7 @@ import { timeMonth, timeWeek, timeYear } from "d3-time";
 import { viewRegister } from "./register";
 import { viewChart } from "./chart";
 import { Account } from "./account";
+import { shortenAccountName } from "./utils";
 
 export const Aggregation = {
   None: null,
@@ -203,7 +204,8 @@ export const ViewSelect = "#main #controls select#view";
 export const StartDateInput = "#main #controls input#start";
 export const EndDateInput = "#main #controls input#end";
 export const ShowClosedAccounts = "#main #controls input#closedAccounts";
-export const AccountOutput = "#main output#account";
+export const AccountName = "#main output#account span#name";
+export const AccountCommodity = "#main output#account span#commodity";
 export const MainView = "#main section#view";
 
 export function emptyElement(selector: string) {
@@ -221,11 +223,11 @@ export function updateView() {
 
 export function updateAccount() {
   const account = State.SelectedAccount;
-  // d3.select(AccountOutput).text(account.fullName);
-  const spans = select(AccountOutput)
-    .selectAll("span")
+  const spans = select(AccountName)
+    .selectAll("span.account")
     .data(account.withAllParents())
     .join("span")
+    .classed("account", true)
     .text((d) => (d.parent ? ":" : ""));
   spans
     .append("a")
@@ -235,6 +237,7 @@ export function updateAccount() {
       if (acc.isParentOf(State.AccountListRoot)) updateAccounts();
       else updateAccount();
     });
+  select(AccountCommodity).text(` (${account.commodity})`);
   updateView();
 }
 
@@ -264,7 +267,7 @@ export function addAccountList() {
     .selectAll("li")
     .data(State.AccountListRoot.allChildren())
     .join("li")
-    .text((d) => State.SelectedAccount.relativeName(d))
+    .text((d) => shortenAccountName(State.SelectedAccount.relativeName(d), 40))
     .on("click", (e: Event) => {
       State.SelectedAccount = (e.currentTarget as liWithAccount).__data__;
       updateAccount();


### PR DESCRIPTION
* compute reverse prices and add them the other accounts
* find shortest conversion chain between commodities and compose them
* add commodity, amount, price parsing and template tag functions for testing
* make Other account use root account commodity
* convert amounts to root account commodity for average computation
* convert amounts to root account commodity for chart bar sizing
* add commodity to account header
* shorten long account names to make them fit better
* bug fixes