### PR TITLE
coin2html: add details popup

### DIFF
--- a/cmd/coin2html/js/body.html
+++ b/cmd/coin2html/js/body.html
@@ -30,6 +30,7 @@
     <section id="view"></section>
   </section>
 </div>
+<div hidden id="details" class="details"></div>
 
 <script src="src/commodity.ts"></script>
 <script src="src/account.ts"></script>

--- a/cmd/coin2html/js/src/chart.ts
+++ b/cmd/coin2html/js/src/chart.ts
@@ -19,7 +19,7 @@ import { scaleLinear, scaleOrdinal, scaleTime } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
 import { select } from "d3-selection";
 
-export function viewChart(options?: {
+export function viewChartTotals(options?: {
   negated?: boolean; // is this negatively denominated account (e.g. Income/Liability)
 }) {
   const containerSelector = MainView;

--- a/cmd/coin2html/js/src/utils.ts
+++ b/cmd/coin2html/js/src/utils.ts
@@ -1,6 +1,6 @@
 import { Account, Posting } from "./account";
 import { Amount, Commodity } from "./commodity";
-import { State } from "./views";
+import { AggregationStyle, State } from "./views";
 
 export function dateToString(date: Date): string {
   return date.toISOString().split("T")[0];
@@ -24,6 +24,12 @@ export type PostingGroup = {
   offset?: number; // used to cache offset value (x) in layered stack chart
   width?: number; // used to cache width value (x) in layered stack chart
 };
+
+export function balanceOrSum(g: PostingGroup) {
+  return State.View.AggregationStyle == AggregationStyle.Flows
+    ? g.sum
+    : g.balance;
+}
 
 export function groupBy(
   postings: Posting[],
@@ -52,6 +58,20 @@ export function groupBy(
     }
     return { date, postings, sum, total: Amount.clone(total), balance };
   });
+}
+
+export function topN(
+  postings: Posting[],
+  n: number,
+  commodity: Commodity
+): Posting[] {
+  const top = [...postings];
+  top.sort(
+    (a, b) =>
+      commodity.convert(a.quantity, a.transaction.posted).toNumber() -
+      commodity.convert(b.quantity, b.transaction.posted).toNumber()
+  );
+  return top.slice(0, n);
 }
 
 // list of groups for an account

--- a/cmd/coin2html/js/src/views.ts
+++ b/cmd/coin2html/js/src/views.ts
@@ -1,9 +1,9 @@
 import { select } from "d3-selection";
 import { timeMonth, timeWeek, timeYear } from "d3-time";
-import { viewRegister } from "./register";
-import { viewChart } from "./chart";
+import { renderPostingsWithSubAccounts, viewRegister } from "./register";
+import { viewChartTotals } from "./chart";
 import { Account } from "./account";
-import { shortenAccountName } from "./utils";
+import { PostingGroup, shortenAccountName, topN } from "./utils";
 
 export const Aggregation = {
   None: null,
@@ -44,11 +44,11 @@ export const State = {
 export const Views = {
   Assets: {
     Register: viewRegister,
-    Chart: viewChart,
+    Chart: viewChartTotals,
   },
   Liabilities: {
     Register: () => viewRegister({ negated: true }),
-    Chart: () => viewChart({ negated: true }),
+    Chart: () => viewChartTotals({ negated: true }),
   },
   Income: {
     Register: () =>
@@ -56,14 +56,14 @@ export const Views = {
         negated: true,
         aggregatedTotal: true,
       }),
-    Chart: () => viewChart({ negated: true }),
+    Chart: () => viewChartTotals({ negated: true }),
   },
   Expenses: {
     Register: () =>
       viewRegister({
         aggregatedTotal: true,
       }),
-    Chart: viewChart,
+    Chart: viewChartTotals,
   },
   Equity: {
     Register: viewRegister,
@@ -207,6 +207,7 @@ export const ShowClosedAccounts = "#main #controls input#closedAccounts";
 export const AccountName = "#main output#account span#name";
 export const AccountCommodity = "#main output#account span#commodity";
 export const MainView = "#main section#view";
+export const Details = "div#details";
 
 export function emptyElement(selector: string) {
   (select(selector).node() as Element).replaceChildren();
@@ -282,4 +283,22 @@ export function updateAccounts() {
   addViewSelect();
   addAccountList();
   updateAccount();
+}
+
+export function showDetails(g: PostingGroup) {
+  emptyElement(Details);
+  const details = select(Details);
+  details
+    .insert("a")
+    .text("X")
+    .on("click", () => details.attr("hidden", true));
+  const account = State.SelectedAccount;
+  renderPostingsWithSubAccounts(
+    account,
+    topN(g.postings, 20, account.commodity),
+    Details,
+    { showLocation: true }
+  );
+
+  details.attr("hidden", null);
 }

--- a/cmd/coin2html/js/styles.css
+++ b/cmd/coin2html/js/styles.css
@@ -45,6 +45,16 @@ label {
   margin: 0.3em;
 }
 
+/* Fixed details div hidden by default */
+div#details {
+  position: fixed;
+  left: 20%;
+  top: 20%;
+  background-color: white;
+  border-style: solid;
+  padding: 10px;
+}
+
 /* VIEW REGISTER */
 table#register {
   width: 100%;


### PR DESCRIPTION
When clicking on a posting group in aggregated register or chart, show the top 20 postings in the group based on the absolute flow amount. Reuses the register view for the detail rendering.

<img width="1305" alt="Screenshot 2024-12-31 at 17 17 32" src="https://github.com/user-attachments/assets/f61b9ff5-7f8c-4c33-a045-bd7a9090774d" />
