### PR TITLE
coin2html: add balances chart

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,6 @@
 ### coin2html
 
 - update user docs in README (details, balances, screenshots ...)
-- balance charts
 - allow dropping subaccounts from aggregations (in both chart and register)
 - filter subaccounts, payee, tag...
 - brush to select date range
@@ -50,5 +49,7 @@
 - commodity renames?
 - language server?
 - lots/costs
+  - https://beancount.github.io/docs/how_inventories_work.html
+  - https://beancount.github.io/docs/a_proposal_for_an_improvement_on_inventory_booking.html
 - multiple commodities in single account?
 - query language

--- a/cmd/coin2html/js/body.html
+++ b/cmd/coin2html/js/body.html
@@ -37,6 +37,7 @@
 <script src="src/utils.ts"></script>
 <script src="src/views.ts"></script>
 <script src="src/viewsBalances.ts"></script>
+<script src="src/viewsBalancesChart.ts"></script>
 <script src="src/viewsRegister.ts"></script>
 <script src="src/viewsAggregatedRegisterChart.ts"></script>
 <script src="src/ui.ts"></script>

--- a/cmd/coin2html/js/src/account.ts
+++ b/cmd/coin2html/js/src/account.ts
@@ -85,6 +85,7 @@ export class Account {
     const balance = this.balanceAt(date);
     const total = Amount.clone(balance);
     for (const child of this.children) {
+      if (!State.ShowClosedAccounts && child.isClosed(date)) continue;
       const childBalances = child.withAllChildBalances(date);
       balances = balances.concat(childBalances);
       total.addIn(childBalances[0].total, date);

--- a/cmd/coin2html/js/src/ui.ts
+++ b/cmd/coin2html/js/src/ui.ts
@@ -16,6 +16,7 @@ import {
   StartDateInput,
   State,
   updateAccounts,
+  updateAggregationForTimeRange,
   updateView,
   Views,
 } from "./views";
@@ -42,6 +43,7 @@ function initializeUI() {
     .on("change", (e) => {
       const input = e.currentTarget as HTMLInputElement;
       State.EndDate = new Date(input.value);
+      updateAggregationForTimeRange();
       updateView();
     });
   select(StartDateInput)
@@ -51,6 +53,7 @@ function initializeUI() {
     .on("change", (e) => {
       const input = e.currentTarget as HTMLInputElement;
       State.StartDate = new Date(input.value);
+      updateAggregationForTimeRange();
       updateView();
     });
   type optionWithAccount = HTMLOptionElement & { __data__: Account };

--- a/cmd/coin2html/js/src/viewsBalances.ts
+++ b/cmd/coin2html/js/src/viewsBalances.ts
@@ -19,9 +19,6 @@ export function viewBalances(options?: {
   const labels = ["Balance", "Total", "Account"];
   const table = addTableWithHeader(containerSelector, labels);
   let balances = account.withAllChildBalances(State.EndDate);
-  if (!State.ShowClosedAccounts) {
-    balances = balances.filter((b) => !b.account.isClosed(State.EndDate));
-  }
   balances = balances.filter(
     (b) => b.account.depthFrom(account) <= State.View.BalanceDepth
   );

--- a/cmd/coin2html/js/src/viewsBalancesChart.ts
+++ b/cmd/coin2html/js/src/viewsBalancesChart.ts
@@ -1,0 +1,141 @@
+import { stratify, treemap } from "d3-hierarchy";
+import { select } from "d3-selection";
+import { group } from "d3-array";
+import {
+  addBalanceDepthInput,
+  emptyElement,
+  MainView,
+  State,
+  updateAccount,
+} from "./views";
+import { scaleSequential } from "d3-scale";
+import { interpolateBlues } from "d3-scale-chromatic";
+import { AccountBalanceAndTotal } from "./utils";
+
+function max(a: number, b: number) {
+  return a > b ? a : b;
+}
+
+// based on https://observablehq.com/@d3/nested-treemap
+export function viewBalancesChart(options?: {
+  negated?: boolean; // is this negatively denominated account (e.g. Income/Liability)
+}) {
+  const containerSelector = MainView;
+  const account = State.SelectedAccount;
+  const opts = { negated: false }; // defaults
+  Object.assign(opts, options);
+  emptyElement(containerSelector);
+  addBalanceDepthInput(containerSelector);
+  const date = State.EndDate;
+  // build the hierarchical data structure that d3 treemap expects
+  let root = stratify<AccountBalanceAndTotal>()
+    .id(({ account }) => account.fullName)
+    .parentId(({ account }) =>
+      account.parent && account.parent != State.SelectedAccount.parent
+        ? account.parent.fullName
+        : undefined
+    )(account.withAllChildBalances(date));
+  // compute the individual node.value that drives the treemap layout
+  root = root.sum((a) =>
+    max(
+      (opts.negated ? -1 : 1) *
+        account.commodity.convert(a.balance, date).toNumber(),
+      0
+    )
+  );
+
+  const [width, height] = [1200, 800];
+  const tm = treemap<AccountBalanceAndTotal>()
+    .size([width, height])
+    .padding(4)
+    .paddingTop(20);
+  const nodes = tm(root);
+  const nodesByDepth = Array.from(group(nodes, (d) => d.depth))
+    .sort((a, b) => a[0] - b[0])
+    .map((d) => d[1])
+    .slice(0, State.View.BalanceDepth);
+
+  let uidCounter = 0;
+
+  const svg = select(containerSelector)
+    .append("svg")
+    .attr("id", "chart")
+    .attr("width", "100%")
+    .attr("height", height);
+  // .attr("viewBox", [0, 0, width, height]);
+  // .attr(
+  //   "style",
+  //   "max-width: 100%; height: auto; overflow: visible; font: 10px sans-serif;"
+  // );
+
+  const color = scaleSequential(
+    [0, nodesByDepth.length * 1.5],
+    interpolateBlues
+  );
+
+  const node = svg
+    .selectAll("g")
+    .data(nodesByDepth)
+    .join("g")
+    .selectAll("g")
+    .data((d) => d)
+    .join("g")
+    .attr("transform", (d) => `translate(${d.x0},${d.y0})`);
+
+  node
+    .append("title")
+    .text(({ data }) =>
+      data.account.children.length > 0 && !data.balance.isZero
+        ? `${data.account.fullName} ${data.total} [ ${data.balance} ]`
+        : `${data.account.fullName} ${data.total}`
+    );
+
+  node
+    .append("rect")
+    .attr("id", (d: any) => (d.nodeUid = `node-${uidCounter++}`))
+    .attr("fill", (d) => color(d.depth))
+    .attr("width", (d) => d.x1 - d.x0)
+    .attr("height", (d) => d.y1 - d.y0)
+    .on("click", (e, { data }) => {
+      State.SelectedAccount = data.account;
+      updateAccount();
+    });
+
+  // add a clippath to clip the text to the rectangle
+  node
+    .append("clipPath")
+    .attr("id", (d: any) => (d.clipUid = `clip-${uidCounter++}`))
+    .append("use")
+    .attr("xlink:href", (d: any) => `#${d.nodeUid}`);
+
+  node
+    .append("text")
+    .attr("clip-path", (d: any) => `url(#${d.clipUid})`)
+    .on("click", (e, { data }) => {
+      State.SelectedAccount = data.account;
+      updateAccount();
+    })
+    .selectAll("tspan")
+    .data(({ data }) => {
+      const bits = [data.account.name, data.total.toString()];
+      if (data.account.children.length > 0 && !data.balance.isZero)
+        bits.push(data.balance.toString());
+      return bits;
+    })
+    .join("tspan")
+    .text((d) => d);
+
+  const narrowBoxLimit = 150;
+  // if the box is wide, put the spans on the same line
+  node
+    .filter((d: any) => d.x1 - d.x0 > narrowBoxLimit)
+    .selectAll("tspan")
+    .attr("dx", 10)
+    .attr("y", 15);
+  // if the box is narrow, put the spans on separate lines
+  node
+    .filter((d) => d.x1 - d.x0 <= narrowBoxLimit)
+    .selectAll("tspan")
+    .attr("x", 10)
+    .attr("dy", 15);
+}


### PR DESCRIPTION
Use a treemap to show balances of selected accounts at the `To:` date. Uses SVG `title` element to show a tooltip with the details, useful when the details get clipped due to the rectangle being too small. Clicking on the rectangle makes the corresponding account the currently selected account.

Also fixes:
* default the aggregation granularity based on the selected time range (the weekly default was annoying for larger time period)
* also adds title element to the register chart to get the details tooltip on hover.

![Screenshot 2025-01-02 at 22 05 26](https://github.com/user-attachments/assets/126d9393-b1c6-4717-aacf-6c79febce152)
