### PR TITLE
coin2html: allow excluding sub-accounts from aggregations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,6 @@
 
 ### coin2html
 
-- allow dropping subaccounts from aggregations (in both chart and register)
 - show reconciliation state in balance view (last reconciled date? vs balance date?)
 - show reconciliation flag in non-aggregated register
 - filter subaccounts, payee, tag...

--- a/cmd/coin2html/README.md
+++ b/cmd/coin2html/README.md
@@ -59,6 +59,10 @@ When aggregating with sub-accounts, the `SubAccount Max` option controls how man
 
 The `Total` column sums up the amounts in the row. The `Cum.Total` is the running total of the rows.
 
+### Aggregation Excluded SubAccounts
+
+When aggregating with sub-accounts, the `Excluded` control shows sub-accounts that are excluded from the sub-account set. When a sub-account set is excluded its data and data of its sub-accounts is eliminated completely from the calculations. A sub-account can be added to the excluded set by clicking on it's heading in the results table, it will then show up in the list next to the `Excluded` label. To add it back in, click the account name in the Excluded list.
+
 ### Aggregation Details
 
 When aggregating each row represents a group of postings. If aggregating with subaccounts each column in the row represents different group of postings. Clicking the amount field opens a `Details` view that lists top 20 postings by the absolute value of their amounts. This can be useful to find any outliers.
@@ -85,6 +89,3 @@ This chart is a visual analog of the tabular Register view when aggregating with
 A hover tooltip shows the amount that each rectangle represents. As with aggregated Register view, clicking a rectangle shows the top 20 posting details
 
 ![Register Chart with Posting Details](https://github.com/user-attachments/assets/0fd171c9-b018-44cc-8d55-f65c806884df)
-
-
-

--- a/cmd/coin2html/js/src/utils.ts
+++ b/cmd/coin2html/js/src/utils.ts
@@ -42,7 +42,7 @@ export function groupBy(
   postings: Posting[],
   groupBy: d3.TimeInterval,
   date: (p: Posting) => Date,
-  commodity: Commodity
+  commodity: Commodity,
 ): PostingGroup[] {
   const groups = new Map<string, Posting[]>();
   for (const p of postings) {
@@ -70,13 +70,13 @@ export function groupBy(
 export function topN(
   postings: Posting[],
   n: number,
-  commodity: Commodity
+  commodity: Commodity,
 ): Posting[] {
   const top = [...postings];
   top.sort((a, b) =>
     commodity
       .convert(b.quantity, b.transaction.posted)
-      .cmp(commodity.convert(a.quantity, a.transaction.posted), true)
+      .cmp(commodity.convert(a.quantity, a.transaction.posted), true),
   );
   return top.slice(0, n);
 }
@@ -90,7 +90,7 @@ export type AccountPostingGroups = {
 // Take an array of account posting groups and total them all.
 function sumAll(
   groups: AccountPostingGroups[],
-  commodity: Commodity
+  commodity: Commodity,
 ): AccountPostingGroups {
   const total = [];
   for (let i = 0; i < groups[0].groups.length; i++) {
@@ -121,15 +121,17 @@ export function groupByWithSubAccounts(
   maxAccounts: number,
   options?: {
     negated?: boolean;
-  }
+    exclude?: Account[];
+  },
 ) {
-  const opts = { negated: false }; // default
+  const opts = { negated: false, exclude: [] }; // default
   Object.assign(opts, options);
   // get all account group lists
   const groups = account.withAllChildPostingGroups(
     State.StartDate,
     State.EndDate,
-    groupKey
+    groupKey,
+    opts.exclude,
   );
   // compute average for each account
   const averages = groups.map((g, i) => {
@@ -149,7 +151,7 @@ export function groupByWithSubAccounts(
     // total the rest into other
     const other = sumAll(
       averages.slice(maxAccounts - 1).map((avg) => groups[avg.index]),
-      account.commodity
+      account.commodity,
     );
     // replace last with other
     top.pop();

--- a/cmd/coin2html/js/src/views.ts
+++ b/cmd/coin2html/js/src/views.ts
@@ -36,6 +36,7 @@ export const State = {
   View: {
     // Should we recurse into subaccounts
     ShowSubAccounts: false,
+    ExcludeSubAccounts: [] as Account[],
     ShowNotes: false, // Show notes in register view
     Aggregate: "None" as keyof typeof Aggregation,
     // How many largest subaccounts to show when aggregating.
@@ -183,7 +184,7 @@ export function addAggregateInput(
   containerSelector: string,
   options?: {
     includeNone?: boolean;
-  }
+  },
 ) {
   const opts = { includeNone: true }; // defaults
   Object.assign(opts, options);
@@ -197,7 +198,7 @@ export function addAggregateInput(
     updateView();
   });
   let data = Object.keys(Aggregation).filter(
-    (k) => opts.includeNone || k != "None"
+    (k) => opts.includeNone || k != "None",
   );
   if (!opts.includeNone && State.View.Aggregate == "None") {
     State.View.Aggregate = data[0] as keyof typeof Aggregation;
@@ -229,6 +230,28 @@ export function addAggregationStyleInput(containerSelector: string) {
     .property("selected", (v) => v == State.View.AggregationStyle)
     .property("value", (v) => v)
     .text((v) => v);
+}
+
+export function addExcludedSubAccountsSpan(
+  containerSelector: string,
+  account: Account,
+) {
+  const container = select(containerSelector);
+  container
+    .append("label")
+    .property("for", "excludedSubAccounts")
+    .text("Exclude");
+  const aggregate = container.append("span").attr("id", "excludedSubAccounts");
+  aggregate
+    .selectAll("span")
+    .data(State.View.ExcludeSubAccounts)
+    .join("span")
+    .on("click", (e, d) => {
+      var i = State.View.ExcludeSubAccounts.indexOf(d);
+      State.View.ExcludeSubAccounts.splice(i, 1);
+      updateView();
+    })
+    .text((v) => ` ${account.relativeName(v)}`);
 }
 
 // UI Node Selectors
@@ -353,7 +376,7 @@ export function showDetails(g: PostingGroup, withSubaccounts = false) {
 }
 export function addTableWithHeader(
   containerSelector: string,
-  labels: string[]
+  labels: string[],
 ) {
   const table = select(containerSelector)
     .append("table")


### PR DESCRIPTION
When aggregating with sub-accounts, the `Excluded` control now shows sub-accounts that are excluded from the sub-account set. When a sub-account set is excluded its data and data of its sub-accounts is eliminated completely from the calculations. A sub-account can be added to the excluded set by clicking on it's heading in the results table, it will then show up in the list next to the `Excluded` label. To add it back in, click the account name in the Excluded list.

* extends the Account api to allow passing in a list of Accounts to exclude
* extends the UI state with the ExcludedSubAccounts list
* extends the aggregated register view to add `Excluded` control to allow adding/removing sub-accounts from the ExcludedSubAccount list
* pass the ExcludedSubAccount list down to the calculations